### PR TITLE
feat: Allow multiple header rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ tables:
   gene-mycn:
     path: genes/table-mycn.csv
     page-size: 40
+    header-rows: 2
 ```
 
 ### tables
@@ -46,6 +47,7 @@ tables:
 | path                              | The path of the CSV/TSV file                 |         |
 | separator                         | The delimiter of the file                    | ,       |
 | page-size                         | Number of rows per page                      | 100     |
+| header-rows                       | Number of header-rows of the file            | 1       |
 | [render-columns](#render-columns) | Configuration of individual column rendering |         |
 
 ### render-columns 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -36,6 +36,10 @@ fn default_page_size() -> usize {
     100_usize
 }
 
+fn default_header_size() -> usize {
+    1_usize
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct TableSpec {
@@ -44,6 +48,8 @@ pub(crate) struct TableSpec {
     pub(crate) separator: char,
     #[serde(default = "default_page_size")]
     pub(crate) page_size: usize,
+    #[serde(default = "default_header_size")]
+    pub(crate) header_rows: usize,
     #[serde(default)]
     pub(crate) render_columns: HashMap<String, RenderColumnSpec>,
 }
@@ -174,6 +180,7 @@ mod tests {
             path: PathBuf::from("test.tsv"),
             separator: ',',
             page_size: 100,
+            header_rows: 1,
             render_columns: HashMap::from([(String::from("x"), expected_render_columns)]),
         };
 

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -28,6 +28,7 @@ $(document).ready(function() {
         data: []
     })
 
+    let additional_headers = [{% if additional_headers %}{% for ah in additional_headers %}{{ "{" }}{% for title in titles %}"{{ title }}":"<b>{{ ah[title] }}</b>"{% if not loop.last %},{% endif %}{% endfor %}{{ "}" }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}];
     let columns = [{% for title in titles %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
     let num = [{% for title in titles %}{{ num[title] }}{% if not loop.last %},{% endif %}{% endfor %}];
     var table_rows = [];
@@ -48,6 +49,7 @@ $(document).ready(function() {
         }
         table_rows.push(row);
     }
+    $('#table').bootstrapTable('append', additional_headers)
     $('#table').bootstrapTable('append', table_rows)
 
     $( ".btn-sm" ).click(function() {
@@ -68,10 +70,10 @@ $(document).ready(function() {
         }
     });
 
-    let to_be_highlighted = window.location.href.toString().split("highlight=").pop();
+    let to_be_highlighted = parseInt(window.location.href.toString().split("highlight=").pop(), 10) + additional_headers.length;
     let rows = $("table > tbody > tr");
     rows.each(function() {
-        if (this.dataset.index === to_be_highlighted) {
+        if (this.dataset.index == to_be_highlighted) {
             $(this).children().addClass('active-row');
             $('#table').bootstrapTable('scrollTo', {unit: 'rows', value: to_be_highlighted})
         }


### PR DESCRIPTION
This PR introduces a new keyword `header-rows` to datavzrd that allows the user to have multiple header rows per table.