### PR TITLE
feat: Add vega-controls option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ tables:
 
 `custom-plot` allows the rendering of customized vega-lite plots per cell.
 
-| keyword   | explanation                                                                                          |
-|-----------|------------------------------------------------------------------------------------------------------|
-| data      | A function to return the data needed for the schema (see below) from the content of the column cell  |
-| schema    | A schema for a vega plot that is rendered into each cell of this column                              |
+| keyword       | explanation                                                                                          | default |
+|---------------|------------------------------------------------------------------------------------------------------|---------|
+| data          | A function to return the data needed for the schema (see below) from the content of the column cell  |         |
+| schema        | A schema for a vega plot that is rendered into each cell of this column                              |         |
+| vega-controls | Whether or not the resulting vega-lite plot is supposed to have action-links in the embedded view    | false   |
 
 ## Authors
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -136,11 +136,18 @@ pub(crate) struct RenderColumnSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct CustomPlot {
     #[serde(default, rename = "data")]
     plot_data: String,
     #[serde(default)]
     schema: String,
+    #[serde(default = "default_vega_controls")]
+    vega_controls: String,
+}
+
+fn default_vega_controls() -> String {
+    "false".to_string()
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -109,7 +109,8 @@ function renderCustomPlots{{ loop.index0 }}(ah, columns) {
         s.data = {};
         s.data.values = data;
         var element_id = `#{{ title }}-${i}`;
-        vegaEmbed(element_id, JSON.parse(JSON.stringify(s)));
+        var opt = {"actions": {{ custom_plot.vega_controls }}};
+        vegaEmbed(element_id, JSON.parse(JSON.stringify(s)), opt);
     }
     let index = columns.indexOf("{{ title }}") + 1;
     $(`table > tbody > tr td:nth-child(${index})`).each(


### PR DESCRIPTION
This PR adds the new keyword `vega-controls` to custom plots that turns vega-embed-controls on or off.