### PR TITLE
feat: Add optional report name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Plots can be fully customized by users via a config file. These also allow the u
 datavzrd allows the user to easily customize it's interactive HTML report via a config file. 
 
 ```yaml
+name: My beautiful datvzrd report
 items:
   table-a:
     path: "table-a.csv"
@@ -90,6 +91,10 @@ items:
               "config": {"legend": {"disable": true}}
             }
 ```
+
+### name
+
+`name` allows the user to optionally set a name for the generated report that will be heading all resulting tables and plots.
 
 ### items
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -113,6 +113,7 @@ impl Renderer for ItemRenderer {
                         table.description.as_deref(),
                         &linked_tables,
                         table.links.as_ref().unwrap(),
+                        &self.specs.report_name,
                     )?;
                 }
                 render_table_javascript(
@@ -152,6 +153,7 @@ fn render_page<P: AsRef<Path>>(
     description: Option<&str>,
     linked_tables: &LinkedTable,
     links: &HashMap<String, LinkSpec>,
+    report_name: &str,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -188,6 +190,7 @@ fn render_page<P: AsRef<Path>>(
     context.insert("description", &description);
     context.insert("tables", tables);
     context.insert("name", name);
+    context.insert("report_name", report_name);
     context.insert("time", &local.format("%a %b %e %T %Y").to_string());
     context.insert("version", &env!("CARGO_PKG_VERSION"));
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -16,6 +16,8 @@ use thiserror::Error;
 pub(crate) struct ItemsSpec {
     #[deref]
     pub(crate) items: HashMap<String, ItemSpecs>,
+    #[serde(default, rename = "name")]
+    pub(crate) report_name: String,
 }
 
 impl ItemsSpec {
@@ -248,9 +250,11 @@ mod tests {
 
         let expected_config = ItemsSpec {
             items: HashMap::from([(String::from("table-a"), expected_table_spec)]),
+            report_name: "my_report".to_string(),
         };
 
         let raw_config = r#"
+    name: my_report    
     items:
         table-a:
             path: test.tsv
@@ -292,6 +296,7 @@ mod tests {
 
         let expected_config = ItemsSpec {
             items: HashMap::from([(String::from("plot-a"), expected_item_spec)]),
+            report_name: "".to_string(),
         };
 
         let raw_config = r#"

--- a/templates/table.html.tera
+++ b/templates/table.html.tera
@@ -49,6 +49,9 @@
         <ul class="navbar-nav mr-auto">
             <li><a href="index_{{ current_page }}.html">{{ name }}</a></li>
         </ul>
+        <ul class="nav navbar-nav mr-auto">
+            <li class="nav-item"><div>{{ report_name }}</div></li>
+        </ul>
         <span class="pull-right">
             {% if description %}
             <div class="btn-group">


### PR DESCRIPTION
This PR introduces a new keyword `name` that allows the user to optionally set a name for the generated report that will be heading all resulting tables and plots.