### PR TITLE
feat: Add pin-columns keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ items:
   gene-mycn-plot:
     path: genes/table-mycn.csv
     header-rows: 2
+    pin-columns: 3
     links:
       some expression:
         column: quality
@@ -107,6 +108,7 @@ items:
 | separator                         | The delimiter of the file                                                                                                                   | ,       |
 | page-size                         | Number of rows per page                                                                                                                     | 100     |
 | header-rows                       | Number of header-rows of the file                                                                                                           | 1       |
+| pin-columns                       | Number columns that are fixed to the left side of the table and therefore always visible.                                                   | 0       |
 | [links](#links)                   | Configuration linking between items                                                                                                         |         |
 | [render-table](#render-table)     | Configuration of individual column rendering                                                                                                |         |
 | [render-plot](#render-plot)       | Configuration of a single plot                                                                                                              |         |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ items:
 | separator                         | The delimiter of the file                                                                                                                   | ,       |
 | page-size                         | Number of rows per page                                                                                                                     | 100     |
 | header-rows                       | Number of header-rows of the file                                                                                                           | 1       |
-| pin-columns                       | Number columns that are fixed to the left side of the table and therefore always visible.                                                   | 0       |
+| pin-columns                       | Number of columns that are fixed to the left side of the table and therefore always visible.                                                   | 0       |
 | [links](#links)                   | Configuration linking between items                                                                                                         |         |
 | [render-table](#render-table)     | Configuration of individual column rendering                                                                                                |         |
 | [render-plot](#render-plot)       | Configuration of a single plot                                                                                                              |         |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ items:
 | separator                         | The delimiter of the file                                                                                                                   | ,       |
 | page-size                         | Number of rows per page                                                                                                                     | 100     |
 | header-rows                       | Number of header-rows of the file                                                                                                           | 1       |
-| pin-columns                       | Number of columns that are fixed to the left side of the table and therefore always visible.                                                   | 0       |
+| pin-columns                       | Number of columns that are fixed to the left side of the table and therefore always visible                                                   | 0       |
 | [links](#links)                   | Configuration linking between items                                                                                                         |         |
 | [render-table](#render-table)     | Configuration of individual column rendering                                                                                                |         |
 | [render-plot](#render-plot)       | Configuration of a single plot                                                                                                              |         |

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -123,6 +123,7 @@ impl Renderer for ItemRenderer {
                     table.separator,
                     table_specs,
                     additional_headers,
+                    table.pin_columns,
                 )?;
                 render_plots(&out_path, &table.path, table.separator, table.header_rows)?;
                 render_search_dialogs(
@@ -213,6 +214,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     separator: char,
     render_columns: &HashMap<String, RenderColumnSpec>,
     additional_headers: Option<Vec<StringRecord>>,
+    pin_columns: usize,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -303,6 +305,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("tick_plots", &tick_plots);
     context.insert("heatmaps", &heatmaps);
     context.insert("num", &numeric);
+    context.insert("pin_columns", &pin_columns);
 
     let file_path = Path::new(output_path.as_ref()).join(Path::new("table").with_extension("js"));
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -63,6 +63,8 @@ pub(crate) struct ItemSpecs {
     pub(crate) page_size: usize,
     #[serde(default = "default_header_size")]
     pub(crate) header_rows: usize,
+    #[serde(default)]
+    pub(crate) pin_columns: usize,
     #[serde(default = "default_links")]
     pub(crate) links: Option<HashMap<String, LinkSpec>>,
     #[serde(rename = "desc")]
@@ -239,6 +241,7 @@ mod tests {
             separator: ',',
             page_size: 100,
             header_rows: 1,
+            pin_columns: 1,
             links: default_links(),
             description: None,
             render_table: Some(HashMap::from([(
@@ -259,6 +262,7 @@ mod tests {
         table-a:
             path: test.tsv
             page-size: 100
+            pin-columns: 1
             render-table:
                 x:
                     link-to-url: https://www.rust-lang.org
@@ -288,6 +292,7 @@ mod tests {
             separator: ',',
             page_size: 100,
             header_rows: 1,
+            pin_columns: 0,
             links: Some(expected_links),
             description: Some("my table".parse().unwrap()),
             render_table: default_render_table(),

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -33,15 +33,15 @@ $(document).ready(function() {
     if (linkouts != null) {
         bs_table_cols.push({field: 'linkouts', title: '', formatter: function(value){ return value }});
         fixed_right = 1;
-        fixed = true;
     }
 
     $('#table').bootstrapTable({
         height: he,
         columns: bs_table_cols,
         data: [],
-        fixedColumns: fixed,
+        fixedColumns: true,
         fixedRightNumber: fixed_right,
+        fixedNumber: {{ pin_columns }}
     })
 
     let additional_headers = [{% if additional_headers %}{% for ah in additional_headers %}{{ "{" }}{% for title in titles %}"{{ title }}":"<b>{{ ah[title] }}</b>"{% if not loop.last %},{% endif %}{% endfor %}{{ "}" }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}];


### PR DESCRIPTION
Add `pin-columns` keyword that lets the user fix columns to the left side of the table that will therefore be always visible.