### PR TITLE
fix: Display correct column on missing value

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -645,7 +645,7 @@ fn render_linkouts(
                 None => {
                     bail!(TableLinkingError::NotFound {
                         not_found: row[index].to_string(),
-                        column: titles[index].to_string(),
+                        column: linked_column.to_string(),
                         table: table.to_string(),
                     })
                 }


### PR DESCRIPTION
This PR fixes the wrong `column` value for the `TableLinkingError::NotFound` error.