### PR TITLE
feat: Allow user to use width: container in vega-lite specs

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -91,6 +91,8 @@ views:
         {
           "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
           "description": "A scatterplot showing movie ratings.",
+          "width": "container",
+          "height": 400,
           "data": {
             "values": []
           },

--- a/static/datavzrd.css
+++ b/static/datavzrd.css
@@ -55,3 +55,7 @@ th .th-inner {
     overflow: visible !important;
     transform-origin: top left;
 }
+
+#vis-container {
+    height: calc(100vh - 200px)
+}

--- a/templates/plot.html.tera
+++ b/templates/plot.html.tera
@@ -82,16 +82,13 @@
     </div>
     {% endif %}
     <div class="row">
-        <div class="col-md-12 text-center">
-            <div id="vis"></div>
+        <div class="col-md-12 d-flex justify-content-center" style="height: calc(100vh - 200px)">
+            <div class="mt-auto mb-auto ml-auto mr-auto" id="vis"></div>
             <script>
                 const specs = {{ specs | safe }};
                 const data = {{ data | safe }};
-
                 specs.data.values = data;
-                specs.width = $( window ).width() - 200;
-                specs.height = $( window ).height() - 200;
-
+                if (specs.width == "container") { $("#vis").css("width", "100%"); }
                 vegaEmbed('#vis', specs);
             </script>
         </div>

--- a/templates/plot.html.tera
+++ b/templates/plot.html.tera
@@ -82,7 +82,7 @@
     </div>
     {% endif %}
     <div class="row">
-        <div class="col-md-12 d-flex justify-content-center" style="height: calc(100vh - 200px)">
+        <div class="col-md-12 d-flex justify-content-center" id="vis-container">
             <div class="mt-auto mb-auto ml-auto mr-auto" id="vis"></div>
             <script>
                 const specs = {{ specs | safe }};


### PR DESCRIPTION
This PR allows the user to use `"width": "container"` in their vega-lite specs and centers smaller plots horizontally and vertically.