### PR TITLE
refactor!: Rename schema to spec and scheme to color-scheme

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -42,7 +42,7 @@ views:
       ## My beatiful oscar scatterplot
       *So many great actors and actresses*
     render-plot:
-      schema: |
+      spec: |
         {
           "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
           "description": "A scatterplot showing oscars.",
@@ -81,13 +81,13 @@ views:
         plot:
           heatmap:
             scale: ordinal
-            scheme: accent
+            color-scheme: accent
   movies-plot:
     dataset: movies
     desc: |
       All movies with its *runtime* and *ratings* plotted over *time*.
     render-plot:
-      schema: |
+      spec: |
         {
           "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
           "description": "A scatterplot showing movie ratings.",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ views:
             function(value) {
               return [{"significance": value, "threshold": value > 60}]
             }
-          schema: |
+          spec: |
             {
               "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
               "mark": "circle",
@@ -89,7 +89,7 @@ views:
     dataset: gene-mycn
     pin-columns: 3
     render-plot:
-      schema: |
+      spec: |
         {
               "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
               "mark": "circle",
@@ -147,7 +147,7 @@ views:
 
 | keyword                           | explanation                                                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| schema                            | A schema for a vega plot that is rendered into each cell of this column                                     |
+| spec                            | A schema for a vega plot that is rendered into each cell of this column                                     |
 
 ### links
 
@@ -166,7 +166,7 @@ views:
 | keyword       | explanation                                                                                          | default |
 |---------------|------------------------------------------------------------------------------------------------------|---------|
 | data          | A function to return the data needed for the schema (see below) from the content of the column cell  |         |
-| schema        | A schema for a vega plot that is rendered into each cell of this column                              |         |
+| spec          | The vega-lite spec for a vega plot that is rendered into each cell of this column                    |         |
 | vega-controls | Whether or not the resulting vega-lite plot is supposed to have action-links in the embedded view    | false   |
 
 ### plot
@@ -190,11 +190,11 @@ views:
 
 `heatmap` defines the attributes of a heatmap for numeric or nominal values.
 
-| keyword   | explanation                                                                                                    |
-|-----------|----------------------------------------------------------------------------------------------------------------|
-| scale     | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                           |
-| scheme    | Defines the [scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values  |
-| range     | Defines the color range of the heatmap as a list                                                  |
+| keyword      | explanation                                                                                                         |
+|--------------|---------------------------------------------------------------------------------------------------------------------|
+| scale        | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                |
+| color-scheme | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values |
+| range        | Defines the color range of the heatmap as a list                                                                    |
 
 ## Authors
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -169,7 +169,7 @@ pub(crate) struct RenderColumnSpec {
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct RenderPlotSpec {
-    #[serde(default)]
+    #[serde(default, rename = "spec")]
     pub(crate) schema: String,
 }
 
@@ -189,7 +189,7 @@ pub(crate) struct LinkSpec {
 pub(crate) struct CustomPlot {
     #[serde(default, rename = "data")]
     plot_data: String,
-    #[serde(default)]
+    #[serde(default, rename = "spec")]
     schema: String,
     #[serde(default = "default_vega_controls")]
     vega_controls: String,
@@ -213,10 +213,11 @@ pub(crate) struct TickPlot {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct Heatmap {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: String,
-    #[serde(default, rename = "scheme")]
+    #[serde(default)]
     color_scheme: String,
     #[serde(default, rename = "range")]
     color_range: Vec<String>,
@@ -347,7 +348,7 @@ mod tests {
             dataset: table-a
             desc: "my table"
             render-plot:
-                schema: |
+                spec: |
                     {'$schema': 'https://vega.github.io/schema/vega-lite/v5.json'}
     "#;
 

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -181,7 +181,7 @@ function renderTickPlots{{ loop.index0 }}(ah, columns) {
 {% for title, tuple in heatmaps %}
 function colorizeColumn{{ loop.index0 }}(ah) {
     var {{ tuple.0.scale }} = vega.scale('{{ tuple.0.scale }}');
-    var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.scale == "ordinal" %}vega.scheme('{{ tuple.0.scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
+    var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.scale == "ordinal" %}vega.scheme('{{ tuple.0.color_scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
     var row_length = $("table > tbody > tr").length - ah;
     for (i = 0; i < row_length; i++) {
         var element = document.getElementById(`{{ title }}-${i}`);


### PR DESCRIPTION
This PR renames `schema` to `spec` and `scheme` to `color-scheme` in the datavzrd config.