### PR TITLE
feat: Add domain keyword for ticks and heatmap

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -28,11 +28,19 @@ views:
           ticks:
             scale: linear
       name:
-        link-to-url: "https://de.wikipedia.org/wiki/{value}"
+        link-to-url: "https://lmgtfy.app/?q={value}"
       movie:
         link-to-url: "https://de.wikipedia.org/wiki/{value}"
       award:
-        link-to-url: "https://lmgtfy.app/?q={value}"
+        plot:
+          heatmap:
+            scale: ordinal
+            domain:
+              - Best actor
+              - Best actress
+            range:
+              - "#add8e6"
+              - "#ffb6c1"
   oscar-plot:
     dataset: oscars
     desc: |
@@ -74,6 +82,9 @@ views:
         plot:
           ticks:
             scale: linear
+            domain:
+              - 1
+              - 10
       Rated:
         plot:
           heatmap:

--- a/README.md
+++ b/README.md
@@ -184,9 +184,10 @@ views:
 
 `ticks` defines the attributes of a [tick-plot](https://vega.github.io/vega-lite/docs/tick.html) for numeric values.
 
-| keyword   | explanation                                                                             |
-|-----------|-----------------------------------------------------------------------------------------|
-| scale     | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot  |
+| keyword   | explanation                                                                                                                       |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| scale     | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot                                            |
+| domain    | Defines the domain of the tick plot. If not present datavzrd will automatically use the minimum and maximum values for the domain |
 
 ### heatmap
 
@@ -197,6 +198,7 @@ views:
 | scale        | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                |
 | color-scheme | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values |
 | range        | Defines the color range of the heatmap as a list                                                                    |
+| domain       | Defines the domain of the heatmap as a list                                                                         |
 
 ## Authors
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -516,7 +516,11 @@ fn render_tick_plot(
         .headers()
         .map(|s| s.iter().position(|t| t == title).unwrap())?;
 
-    let (min, max) = get_min_max(csv_path, separator, column_index, header_rows)?;
+    let (min, max) = if let Some(domain) = &tick_plot.domain {
+        (domain[0], domain[1])
+    } else {
+        get_min_max(csv_path, separator, column_index, header_rows)?
+    };
 
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -539,6 +543,10 @@ fn get_column_domain(
     header_rows: usize,
     heatmap: &Heatmap,
 ) -> Result<String> {
+    if let Some(domain) = &heatmap.domain {
+        return Ok(json!(domain).to_string());
+    }
+
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(separator as u8)
         .from_path(csv_path)

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -210,6 +210,8 @@ pub(crate) struct PlotSpec {
 pub(crate) struct TickPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: String,
+    #[serde(default)]
+    pub(crate) domain: Option<Vec<f32>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -221,6 +223,8 @@ pub(crate) struct Heatmap {
     color_scheme: String,
     #[serde(default, rename = "range")]
     color_range: Vec<String>,
+    #[serde(default)]
+    pub(crate) domain: Option<Vec<String>>,
 }
 
 #[derive(Error, Debug)]

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -181,7 +181,7 @@ function renderTickPlots{{ loop.index0 }}(ah, columns) {
 {% for title, tuple in heatmaps %}
 function colorizeColumn{{ loop.index0 }}(ah) {
     var {{ tuple.0.scale }} = vega.scale('{{ tuple.0.scale }}');
-    var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.scale == "ordinal" %}vega.scheme('{{ tuple.0.color_scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
+    var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.color_scheme %}vega.scheme('{{ tuple.0.color_scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
     var row_length = $("table > tbody > tr").length - ah;
     for (i = 0; i < row_length; i++) {
         var element = document.getElementById(`{{ title }}-${i}`);


### PR DESCRIPTION
This PR adds a new keyword `domain` for `ticks` and `heatmap` that allows the user to define domains themselves.