### PR TITLE
feat: Add optional keyword for render-table

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -29,6 +29,11 @@ views:
             scale: linear
       name:
         link-to-url: "https://lmgtfy.app/?q={value}"
+      pups:
+        optional: true
+        plot:
+          ticks:
+            scale: linear
       movie:
         link-to-url: "https://de.wikipedia.org/wiki/{value}"
       award:

--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -29,11 +29,6 @@ views:
             scale: linear
       name:
         link-to-url: "https://lmgtfy.app/?q={value}"
-      pups:
-        optional: true
-        plot:
-          ticks:
-            scale: linear
       movie:
         link-to-url: "https://de.wikipedia.org/wiki/{value}"
       award:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ views:
     dataset: table-b
     render-table:
       significance:
+        optional: true
         custom-plot:
           data: |
             function(value) {
@@ -136,12 +137,13 @@ views:
 
 `render-table` contains individual configurations for each column that can either be adressed by its name defined in the header of the CSV/TSV file or its 0-based index (e.g. `index(5)` for the 6th column):
 
-| keyword                           | explanation                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| link-to-url                       | Renders a link to the given url with {value} replace by the value of the table                              |
-| custom                            | Applies the given js function to render column content. The parameters of the function are similar to the ones defined [here](https://bootstrap-table.com/docs/api/column-options/#formatter) |
-| [custom-plot](#custom-plot)       | Renders a custom vega-lite plot to the corresponding table cell                                             |
-| [plot](#plot)                     | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                         |
+| keyword                           | explanation                                                                                                 | default |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| link-to-url                       | Renders a link to the given url with {value} replace by the value of the table                              |         |
+| custom                            | Applies the given js function to render column content. The parameters of the function are similar to the ones defined [here](https://bootstrap-table.com/docs/api/column-options/#formatter) |         |
+| [custom-plot](#custom-plot)       | Renders a custom vega-lite plot to the corresponding table cell                                             |         |
+| [plot](#plot)                     | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                         |         |
+| optional                          | Allows to have a column specified in render-table that is actually not present.                             | false   |
 
 ### render-plot
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -81,11 +81,6 @@ impl Renderer for ItemRenderer {
                 }
                 // Render table
                 else if let Some(table_specs) = &table.render_table {
-                    let table_specs = &table_specs
-                        .clone()
-                        .into_iter()
-                        .filter(|(_, s)| !s.optional)
-                        .collect();
                     let row_address_factory = RowAddressFactory::new(table.page_size);
                     let pages = row_address_factory
                         .get(records_length - dataset.header_rows)
@@ -95,6 +90,12 @@ impl Renderer for ItemRenderer {
                     let mut reader = generate_reader()
                         .context(format!("Could not read file with path {:?}", &dataset.path))?;
                     let headers = reader.headers()?.iter().map(|s| s.to_owned()).collect_vec();
+
+                    let table_specs = &table_specs
+                        .clone()
+                        .into_iter()
+                        .filter(|(k, s)| !s.optional || headers.contains(k))
+                        .collect();
 
                     let additional_headers = if dataset.header_rows > 1 {
                         let mut additional_header_reader = generate_reader().context(format!(

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -81,6 +81,11 @@ impl Renderer for ItemRenderer {
                 }
                 // Render table
                 else if let Some(table_specs) = &table.render_table {
+                    let table_specs = &table_specs
+                        .clone()
+                        .into_iter()
+                        .filter(|(_, s)| !s.optional)
+                        .collect();
                     let row_address_factory = RowAddressFactory::new(table.page_size);
                     let pages = row_address_factory
                         .get(records_length - dataset.header_rows)

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -155,6 +155,8 @@ impl ItemSpecs {
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct RenderColumnSpec {
     #[serde(default)]
+    pub(crate) optional: bool,
+    #[serde(default)]
     pub(crate) custom: Option<String>,
     #[serde(default)]
     pub(crate) link_to_url: Option<String>,
@@ -251,6 +253,7 @@ mod tests {
     #[test]
     fn test_table_config_deserialization() {
         let expected_render_columns = RenderColumnSpec {
+            optional: false,
             custom: None,
             link_to_url: Some(String::from("https://www.rust-lang.org")),
             plot: None,


### PR DESCRIPTION
This PR adds the keyword `optional` to columns defined in `render-table` that allows the user to have a column specified in `render-table` that is actually not present.