### PR TITLE
feat: Make entire row available to link-to-url

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -28,7 +28,7 @@ views:
           ticks:
             scale: linear
       name:
-        link-to-url: "https://lmgtfy.app/?q={value}"
+        link-to-url: "https://lmgtfy.app/?q=Is {name} in {movie}?"
       movie:
         link-to-url: "https://de.wikipedia.org/wiki/{value}"
       award:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ views:
 
 | keyword                           | explanation                                                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| link-to-url                       | Renders a link to the given url with {value} replace by the value of the table                              |
+| link-to-url                       | Renders a link to the given url with {value} replace by the value of the table. Other values of the same row can be accessed by their column header (e.g. {age} for a column named age).      |
 | custom                            | Applies the given js function to render column content. The parameters of the function are similar to the ones defined [here](https://bootstrap-table.com/docs/api/column-options/#formatter) |
 | [custom-plot](#custom-plot)       | Renders a custom vega-lite plot to the corresponding table cell                                             |
 | [plot](#plot)                     | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                         |

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -360,7 +360,10 @@ fn link_columns(
     let mut result = Vec::new();
     for (i, title) in titles.iter().enumerate() {
         if let Some(render_column) = render_columns.get(title) {
-            if let Some(link) = render_column.link_to_url.clone() {
+            if let Some(mut link) = render_column.link_to_url.clone() {
+                for (j, t) in titles.iter().enumerate() {
+                    link = link.replace(&format!("{{{t}}}"), &column[j])
+                }
                 result.push(format!(
                     "<a href='{}' target='_blank' >{}</a>",
                     link.replace("{value}", &column[i]),

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -325,6 +325,17 @@ fn render_table_javascript<P: AsRef<Path>>(
         })
         .collect();
 
+    let link_urls: HashMap<String, String> = render_columns
+        .iter()
+        .filter(|(_, k)| k.link_to_url.is_some())
+        .map(|(t, spec)| {
+            (
+                t.to_string(),
+                spec.link_to_url.as_ref().unwrap().to_string(),
+            )
+        })
+        .collect();
+
     let header_rows = additional_headers.map(|headers| {
         headers
             .iter()
@@ -343,6 +354,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("custom_plots", &custom_plots);
     context.insert("tick_plots", &tick_plots);
     context.insert("heatmaps", &heatmaps);
+    context.insert("link_urls", &link_urls);
     context.insert("num", &numeric);
     context.insert("pin_columns", &pin_columns);
 
@@ -366,16 +378,7 @@ fn link_columns(
     let mut result = Vec::new();
     for (i, title) in titles.iter().enumerate() {
         if let Some(render_column) = render_columns.get(title) {
-            if let Some(mut link) = render_column.link_to_url.clone() {
-                for (j, t) in titles.iter().enumerate() {
-                    link = link.replace(&format!("{{{t}}}"), &column[j])
-                }
-                result.push(format!(
-                    "<a href='{}' target='_blank' >{}</a>",
-                    link.replace("{value}", &column[i]),
-                    column[i]
-                ));
-            } else if render_column.custom_plot.is_some() || render_column.plot.is_some() {
+            if render_column.custom_plot.is_some() || render_column.plot.is_some() {
                 result.push(format!(
                     "<div id='{}-{}' data-value='{}'>{}</div>",
                     slugify!(title),

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -205,7 +205,6 @@ function colorizeColumn{{ loop.index0 }}(ah) {
                 link = link_url.replaceAll("{value}", value);
                 for (column of columns) {
                 {% raw %}link = link.replaceAll(`{${column}}`, table_rows[row][column]);{% endraw %}
-                    console.log(link);
                 }
                 this.innerHTML = `<a href='${link}' target='_blank' >${value}</a>`;
                 row++;

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -103,6 +103,10 @@ $(document).ready(function() {
         renderTickPlots{{ loop.index0 }}(additional_headers.length, columns);
     {% endfor %}
 
+    {% for title, link_url in link_urls %}
+        linkUrlColumn{{ loop.index0 }}(additional_headers.length, columns, table_rows);
+    {% endfor %}
+
     {% for title, tick_plot in heatmaps %}
         colorizeColumn{{ loop.index0 }}(additional_headers.length);
     {% endfor %}
@@ -188,6 +192,26 @@ function colorizeColumn{{ loop.index0 }}(ah) {
         element.parentElement.style.backgroundColor = scale(element.dataset.value);
     }
 }
+{% endfor %}
+
+{% for title, link_url in link_urls %}
+    function linkUrlColumn{{ loop.index0 }}(ah, columns, table_rows) {
+        let index = columns.indexOf("{{ title }}") + 1;
+        let link_url = "{{ link_url }}";
+        let row = 0;
+        $(`table > tbody > tr td:nth-child(${index})`).each(
+            function() {
+                value = this.innerHTML;
+                link = link_url.replaceAll("{value}", value);
+                for (column of columns) {
+                {% raw %}link = link.replaceAll(`{${column}}`, table_rows[row][column]);{% endraw %}
+                    console.log(link);
+                }
+                this.innerHTML = `<a href='${link}' target='_blank' >${value}</a>`;
+                row++;
+            }
+        );
+    }
 {% endfor %}
 
 function embedSearch(index) {


### PR DESCRIPTION
This PR makes the entire row available for use in `link-to-url`. This makes something like this possible:
```yaml
render-table:
      name:
        link-to-url: "https://lmgtfy.app/?q=Is {name} in {movie}?"
```
with a csv file looking like this:
|name|movie|
|-----|------|
|Samuel L. Jackson|Pulp Fiction|
|Ryan Reynolds|Deadpool|        