### PR TITLE
feat: New keyword spec-path

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -47,30 +47,7 @@ views:
       ## My beatiful oscar scatterplot
       *So many great actors and actresses*
     render-plot:
-      spec: |
-        {
-          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-          "description": "A scatterplot showing oscars.",
-          "data": {
-            "values": []
-          },
-          "mark": {"type": "point", "tooltip": {"content": "data"}},
-          "encoding": {
-            "x": {
-              "field": "oscar_yr",
-              "type": "quantitative",
-              "scale": {"zero": false}
-            },
-            "y": {
-              "field": "age",
-              "type": "quantitative",
-              "scale": {"zero": false}
-            },
-            "href": {"field": "link to oscar entry"},
-            "color": {"field": "award", "type": "nominal"},
-            "shape": {"field": "award", "type": "nominal"}
-          }
-        }
+      spec-path: ".examples/specs/oscars.vl.json"
   movies:
     dataset: movies
     render-table:
@@ -95,37 +72,4 @@ views:
     desc: |
       All movies with its *runtime* and *ratings* plotted over *time*.
     render-plot:
-      spec: |
-        {
-          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-          "description": "A scatterplot showing movie ratings.",
-          "width": "container",
-          "height": 400,
-          "data": {
-            "values": []
-          },
-          "transform": [
-            {"calculate": "parseInt(datum.Runtime)", "as": "parsed_runtime"}
-          ],
-          "mark": {"type": "circle", "opacity": 0.8, "tooltip": {"content": "data"}},
-          "encoding": {
-            "x": {
-              "field": "Year",
-              "type": "quantitative",
-              "scale": {"zero": false}
-            },
-            "size": {
-              "title": "Runtime",
-              "field": "parsed_runtime",
-              "type": "quantitative",
-              "scale": {"zero": false}
-            },
-            "y": {
-              "field": "imdbRating",
-              "type": "quantitative",
-              "scale": {"zero": false}
-            },
-            "href": {"field": "link to oscar entry"},
-            "color": {"field": "Rated", "type": "nominal"},
-          }
-        }
+      spec-path: ".examples/specs/movies.vl.json"

--- a/.examples/specs/movies.vl.json
+++ b/.examples/specs/movies.vl.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A scatterplot showing movie ratings.",
+  "width": "container",
+  "height": 400,
+  "data": {
+    "values": []
+  },
+  "transform": [
+    {"calculate": "parseInt(datum.Runtime)", "as": "parsed_runtime"}
+  ],
+  "mark": {"type": "circle", "opacity": 0.8, "tooltip": {"content": "data"}},
+  "encoding": {
+    "x": {
+      "field": "Year",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "size": {
+      "title": "Runtime",
+      "field": "parsed_runtime",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "y": {
+      "field": "imdbRating",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "href": {"field": "link to oscar entry"},
+    "color": {"field": "Rated", "type": "nominal"},
+  }
+}

--- a/.examples/specs/oscars.vl.json
+++ b/.examples/specs/oscars.vl.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A scatterplot showing oscars.",
+  "data": {
+    "values": []
+  },
+  "mark": {"type": "point", "tooltip": {"content": "data"}},
+  "encoding": {
+    "x": {
+      "field": "oscar_yr",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "y": {
+      "field": "age",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "href": {"field": "link to oscar entry"},
+    "color": {"field": "award", "type": "nominal"},
+    "shape": {"field": "award", "type": "nominal"}
+  }
+}

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ views:
 
 | keyword                           | explanation                                                                                                 |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| spec                              | A schema for a vega plot that is rendered into each cell of this column                                     |
+| spec                              | A schema for a vega lite plot that will be rendered to a single view                                        |
+| spec-path                         | The path to a file containing a schema for a vega lite plot that will be rendered to a single view          |
 
 ### links
 
@@ -167,11 +168,12 @@ views:
 
 `custom-plot` allows the rendering of customized vega-lite plots per cell.
 
-| keyword       | explanation                                                                                          | default |
-|---------------|------------------------------------------------------------------------------------------------------|---------|
-| data          | A function to return the data needed for the schema (see below) from the content of the column cell  |         |
-| spec          | The vega-lite spec for a vega plot that is rendered into each cell of this column                    |         |
-| vega-controls | Whether or not the resulting vega-lite plot is supposed to have action-links in the embedded view    | false   |
+| keyword       | explanation                                                                                                | default |
+|---------------|------------------------------------------------------------------------------------------------------------|---------|
+| data          | A function to return the data needed for the schema (see below) from the content of the column cell        |         |
+| spec          | The vega-lite spec for a vega plot that is rendered into each cell of this column                          |         |
+| spec-path     | The path to a file containing a schema for a vega-lite plot that is rendered into each cell of this column |         |
+| vega-controls | Whether or not the resulting vega-lite plot is supposed to have action-links in the embedded view          | false   |
 
 ### plot
 


### PR DESCRIPTION
This PR introduces a new keyword `spec-path` that allows the user to have their Vega-Lite specs in separate files cleaning up bigger config files.