### PR TITLE
feat: New keyword display-mode

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -23,6 +23,14 @@ views:
       This table contains *all* winning oscars for best actress and best actor.
     page-size: 25
     render-table:
+      oscar_no:
+        display-mode: detail
+      birth_mo:
+        display-mode: detail
+      birth_d:
+        display-mode: detail
+      birth_y:
+        display-mode: detail
       age:
         plot:
           ticks:

--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ views:
 
 `render-table` contains individual configurations for each column that can either be adressed by its name defined in the header of the CSV/TSV file or its 0-based index (e.g. `index(5)` for the 6th column):
 
-| keyword                           | explanation                                                                                                 | default |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| keyword                           | explanation                                                                                                                                                                                   | default |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | link-to-url                       | Renders a link to the given url with {value} replace by the value of the table. Other values of the same row can be accessed by their column header (e.g. {age} for a column named age).      |         |
 | custom                            | Applies the given js function to render column content. The parameters of the function are similar to the ones defined [here](https://bootstrap-table.com/docs/api/column-options/#formatter) |         |
-| [custom-plot](#custom-plot)       | Renders a custom vega-lite plot to the corresponding table cell                                             |         |
-| [plot](#plot)                     | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                         |         |
-| optional                          | Allows to have a column specified in render-table that is actually not present.                             | false   |
+| [custom-plot](#custom-plot)       | Renders a custom vega-lite plot to the corresponding table cell                                                                                                                               |         |
+| [plot](#plot)                     | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                                                                                                           |         |
+| optional                          | Allows to have a column specified in render-table that is actually not present.                                                                                                               | false   |
+| display-mode                      | Allows to have a column only in [detail view](https://examples.bootstrap-table.com/#options/detail-view.html#view-source) by setting this to `detail`.                                        | normal  |
 
 ### render-plot
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -340,6 +340,19 @@ fn render_table_javascript<P: AsRef<Path>>(
         })
         .collect();
 
+    let mut display_modes: HashMap<String, String> = titles
+        .iter()
+        .map(|t| (t.to_string(), "normal".to_string()))
+        .collect();
+    for (title, rc) in render_columns {
+        display_modes.insert(title.to_string(), rc.display_mode.to_string());
+    }
+    let detail_mode = display_modes
+        .iter()
+        .filter(|(_, mode)| *mode != "normal")
+        .count()
+        > 0;
+
     let header_rows = additional_headers.map(|headers| {
         headers
             .iter()
@@ -358,6 +371,8 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("custom_plots", &custom_plots);
     context.insert("tick_plots", &tick_plots);
     context.insert("heatmaps", &heatmaps);
+    context.insert("display_modes", &display_modes);
+    context.insert("detail_mode", &detail_mode);
     context.insert("link_urls", &link_urls);
     context.insert("num", &numeric);
     context.insert("pin_columns", &pin_columns);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -153,6 +153,10 @@ impl ItemSpecs {
     }
 }
 
+fn default_display_mode() -> String {
+    String::from("normal")
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct RenderColumnSpec {
@@ -160,6 +164,8 @@ pub(crate) struct RenderColumnSpec {
     pub(crate) optional: bool,
     #[serde(default)]
     pub(crate) custom: Option<String>,
+    #[serde(default = "default_display_mode")]
+    pub(crate) display_mode: String,
     #[serde(default)]
     pub(crate) link_to_url: Option<String>,
     #[serde(default)]
@@ -285,6 +291,7 @@ mod tests {
         let expected_render_columns = RenderColumnSpec {
             optional: false,
             custom: None,
+            display_mode: "normal".to_string(),
             link_to_url: Some(String::from("https://www.rust-lang.org")),
             plot: None,
             custom_plot: None,

--- a/static/datavzrd.css
+++ b/static/datavzrd.css
@@ -66,3 +66,18 @@ th .th-inner {
 #vis-container {
     height: calc(100vh - 200px)
 }
+
+.fa {
+    display:inline-block;
+    width: 24px;
+    height: 24px;
+    background-size: 100%;
+}
+
+.fa-minus {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z"/></svg>');
+}
+
+.fa-plus {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>');
+}

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -21,11 +21,11 @@ $(document).ready(function() {
 
     var he = $( window ).height() - 195;
 
-    let bs_table_cols = [{% for title in titles %}{
+    let bs_table_cols = [{% for title in titles %}{% if display_modes[title] == "normal" %}{
     field: '{{ title }}',
     title: '{{ title }}\r\n                        <a class=\"sym\" data-toggle=\"modal\" data-target=\"#modal_{{ loop.index0 }}\" onclick=\"if (show_plot_{{ loop.index0 }}) {vegaEmbed(\'#plot_{{ loop.index0 }}\', plot_{{ loop.index0 }})} else {document.getElementById(\'plot_{{ loop.index0 }}\').innerHTML = \'<p>No reasonable plot possible.</p>\'}\">\r\n                            <svg width=\"1em\" height=\"1em\" viewBox=\"0 0 16 16\" class=\"bi bi-bar-chart-fill\" fill=\"currentColor\" xmlns=\"http:\/\/www.w3.org\/2000\/svg\">\r\n                                <rect width=\"4\" height=\"5\" x=\"1\" y=\"10\" rx=\"1\"\/>\r\n                                <rect width=\"4\" height=\"9\" x=\"6\" y=\"6\" rx=\"1\"\/>\r\n                                <rect width=\"4\" height=\"14\" x=\"11\" y=\"1\" rx=\"1\"\/>\r\n                            <\/svg>\r\n                        <\/a>\r\n                        <a class=\"sym\" data-toggle=\"modal\" onclick=\"embedSearch({{ loop.index0 }})\" data-target=\"#search\">\r\n                        <svg width=\"1em\" height=\"1em\" viewBox=\"0 0 16 16\" class=\"bi bi-search\" fill=\"currentColor\" xmlns=\"http:\/\/www.w3.org\/2000\/svg\">\r\n                                <path fill-rule=\"evenodd\" d=\"M10.442 10.442a1 1 0 0 1 1.415 0l3.85 3.85a1 1 0 0 1-1.414 1.415l-3.85-3.85a1 1 0 0 1 0-1.415z\"\/>\r\n                                <path fill-rule=\"evenodd\" d=\"M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zM13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0z\"\/>\r\n                            <\/svg>\r\n                        <\/a>'{% if formatter %},
         formatter: function(value, row, index, field) { if (format["{{ title }}"] != undefined){ return format["{{ title }}"](value, row, index, field) } else { return value } }{% endif %}
-    }{% if not loop.last %},{% endif %}{% endfor %}];
+    }{% if not loop.last %},{% endif %}{% endif %}{% endfor %}];
 
     var fixed_right = 0;
     var fixed = false;
@@ -39,6 +39,7 @@ $(document).ready(function() {
         height: he,
         columns: bs_table_cols,
         data: [],
+        {% if detail_mode %}detailView: true, detailFormatter: "detailFormatter",{% endif %}
         fixedColumns: true,
         fixedRightNumber: fixed_right,
         fixedNumber: {{ pin_columns }}
@@ -46,6 +47,7 @@ $(document).ready(function() {
 
     let additional_headers = [{% if additional_headers %}{% for ah in additional_headers %}{{ "{" }}{% for title in titles %}"{{ title }}":"<b>{{ ah[title] }}</b>"{% if not loop.last %},{% endif %}{% endfor %}{{ "}" }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}];
     let columns = [{% for title in titles %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
+    let displayed_columns = [{% for title in titles %}{% if display_modes[title] == "normal" %}"{{ title }}"{% if not loop.last %},{% endif %}{% endif %}{% endfor %}];
     let num = [{% for title in titles %}{{ num[title] }}{% if not loop.last %},{% endif %}{% endfor %}];
     var table_rows = [];
     var j = 0;
@@ -96,15 +98,15 @@ $(document).ready(function() {
     });
 
     {% for title, custom_plot in custom_plots %}
-    renderCustomPlots{{ loop.index0 }}(additional_headers.length, columns);
+    renderCustomPlots{{ loop.index0 }}(additional_headers.length, displayed_columns);
     {% endfor %}
 
     {% for title, tick_plot in tick_plots %}
-        renderTickPlots{{ loop.index0 }}(additional_headers.length, columns);
+        renderTickPlots{{ loop.index0 }}(additional_headers.length, displayed_columns);
     {% endfor %}
 
     {% for title, link_url in link_urls %}
-        linkUrlColumn{{ loop.index0 }}(additional_headers.length, columns, table_rows);
+        linkUrlColumn{{ loop.index0 }}(additional_headers.length, displayed_columns, table_rows);
     {% endfor %}
 
     {% for title, tick_plot in heatmaps %}
@@ -172,7 +174,7 @@ function renderTickPlots{{ loop.index0 }}(ah, columns) {
         var opt = {"actions": false};
         vegaEmbed(element_id, JSON.parse(JSON.stringify(s)), opt);
     }
-    let index = columns.indexOf("{{ title }}") + 1;
+    let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
     $(`table > tbody > tr td:nth-child(${index})`).each(
         function() {
             this.classList.add("plotcell");
@@ -196,7 +198,7 @@ function colorizeColumn{{ loop.index0 }}(ah) {
 
 {% for title, link_url in link_urls %}
     function linkUrlColumn{{ loop.index0 }}(ah, columns, table_rows) {
-        let index = columns.indexOf("{{ title }}") + 1;
+        let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
         let link_url = "{{ link_url }}";
         let row = 0;
         $(`table > tbody > tr td:nth-child(${index})`).each(
@@ -217,3 +219,13 @@ function embedSearch(index) {
     var source = `search/column_${index}.html`;
     document.getElementById('search-iframe').setAttribute("src",source);
 }
+
+{% if detail_mode %}
+function detailFormatter(index, row) {
+    var html = []
+    $.each(row, function (key, value) {
+        html.push('<p><b>' + key + ':</b> ' + value + '</p>')
+    })
+    return html.join('')
+}
+{% endif %}


### PR DESCRIPTION
This PR implements a new keyword `display-mode` that allows user to see specified columns only in [detail view](https://examples.bootstrap-table.com/#options/detail-view.html#view-source).