### PR TITLE
fix: Fix example config

### DIFF
--- a/.examples/specs/oscars.vl.json
+++ b/.examples/specs/oscars.vl.json
@@ -16,7 +16,7 @@
       "type": "quantitative",
       "scale": {"zero": false}
     },
-    "href": {"field": "link to oscar entry"},
+    "href": {"field": "link to movie"},
     "color": {"field": "award", "type": "nominal"},
     "shape": {"field": "award", "type": "nominal"}
   }


### PR DESCRIPTION
Just a quick fix of the example config that had the wrong linkout in the oscar-plot spec. 