### PR TITLE
fix: Do not require empty data for plots

### DIFF
--- a/.examples/specs/movies.vl.json
+++ b/.examples/specs/movies.vl.json
@@ -3,9 +3,6 @@
   "description": "A scatterplot showing movie ratings.",
   "width": "container",
   "height": 400,
-  "data": {
-    "values": []
-  },
   "transform": [
     {"calculate": "parseInt(datum.Runtime)", "as": "parsed_runtime"}
   ],
@@ -28,6 +25,6 @@
       "scale": {"zero": false}
     },
     "href": {"field": "link to oscar entry"},
-    "color": {"field": "Rated", "type": "nominal"},
+    "color": {"field": "Rated", "type": "nominal"}
   }
 }

--- a/.examples/specs/oscars.vl.json
+++ b/.examples/specs/oscars.vl.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "description": "A scatterplot showing oscars.",
-  "data": {
-    "values": []
-  },
   "mark": {"type": "point", "tooltip": {"content": "data"}},
   "encoding": {
     "x": {

--- a/templates/plot.html.tera
+++ b/templates/plot.html.tera
@@ -87,6 +87,7 @@
             <script>
                 const specs = {{ specs | safe }};
                 const data = {{ data | safe }};
+                specs.data = {};
                 specs.data.values = data;
                 if (specs.width == "container") { $("#vis").css("width", "100%"); }
                 vegaEmbed('#vis', specs);


### PR DESCRIPTION
This PR makes datavzrd not require `data` i.e. 
```json
"data": { "values": [] }
```
 for plots anymore. Right now plots without defined `data` will not show properly. @FelixMoelder discovered this and we thought it might make sense to not require it. 
 