### PR TITLE
fix: No linebreaks in numeric cells

### DIFF
--- a/static/datavzrd.css
+++ b/static/datavzrd.css
@@ -81,3 +81,7 @@ th .th-inner {
 .fa-plus {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>');
 }
+
+.num-cell {
+    white-space: nowrap;
+}

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -49,6 +49,7 @@ $(document).ready(function() {
     let columns = [{% for title in titles %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
     let displayed_columns = [{% for title in titles %}{% if display_modes[title] == "normal" %}"{{ title }}"{% if not loop.last %},{% endif %}{% endif %}{% endfor %}];
     let num = [{% for title in titles %}{{ num[title] }}{% if not loop.last %},{% endif %}{% endfor %}];
+    let dp_num = [{% for title in titles %}{% if display_modes[title] == "normal" %}{{ num[title] }}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}];
     let ticks = [{% for title, tick_plot in tick_plots %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
     let cp = [{% for title, custom_plot in custom_plots %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
     let links = [{% for title, link_url in link_urls %}"{{ title }}"{% if not loop.last %},{% endif %}{% endfor %}];
@@ -103,7 +104,7 @@ $(document).ready(function() {
             {% endfor %}
         }
     });
-
+    addNumClass(dp_num, additional_headers.length);
     {% for title, custom_plot in custom_plots %}
     renderCustomPlots{{ loop.index0 }}(additional_headers.length, displayed_columns);
     {% endfor %}
@@ -258,3 +259,23 @@ function detailFormatter(index, row) {
     return html.join('')
 }
 {% endif %}
+
+function addNumClass(dp_num, ah) {
+    for (let i in dp_num) {
+        if (dp_num[i]) {
+            let row = 0;
+            let n = parseInt(i) + {% if detail_mode %} + 2{% else %} + 1{% endif %};
+            $(`table > tbody > tr td:nth-child(${n})`).each(
+                function() {
+                    console.log(this);
+                    if (row < ah) {
+                        row++;
+                        return;
+                    }
+                    this.classList.add("num-cell");
+                    row++;
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR prevents cells with numbers having line breaks by adding `white-space: nowrap`.