### PR TITLE
fix: Missing columns when in detail mode for link-url

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -106,7 +106,7 @@ $(document).ready(function() {
     {% endfor %}
 
     {% for title, link_url in link_urls %}
-        linkUrlColumn{{ loop.index0 }}(additional_headers.length, displayed_columns, table_rows);
+        linkUrlColumn{{ loop.index0 }}(additional_headers.length, displayed_columns, table_rows, columns);
     {% endfor %}
 
     {% for title, tick_plot in heatmaps %}
@@ -215,8 +215,8 @@ function colorizeColumn{{ loop.index0 }}(ah, columns) {
 {% endfor %}
 
 {% for title, link_url in link_urls %}
-    function linkUrlColumn{{ loop.index0 }}(ah, columns, table_rows) {
-        let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
+    function linkUrlColumn{{ loop.index0 }}(ah, dp_columns, table_rows, columns) {
+        let index = dp_columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
         let link_url = "{{ link_url }}";
         let row = 0;
         $(`table > tbody > tr td:nth-child(${index})`).each(


### PR DESCRIPTION
This PR fixes a problem where columns with `display-mode: detail` were not accessible from `link-url`.