### PR TITLE
feat: Add default-view keyword

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -15,6 +15,7 @@ datasets:
       link to oscar entry:
         column: Title
         table-row: oscars/movie
+default-view: oscars
 views:
   oscars:
     dataset: oscars

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ views:
 
 `name` allows the user to optionally set a name for the generated report that will be heading all resulting tables and plots.
 
+### default-view
+
+`default-view` allows the user to optionally specify a view for the generated report that will be shown when opening the index file.
+
 ### datasets
 
 `datasets` defines the different datasets of the report. This is also the place to define links between your individual datasets.

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -67,7 +67,11 @@ pub(crate) fn render_static_files<P: AsRef<Path>>(path: P) -> Result<()> {
 }
 
 pub(crate) fn render_index_file<P: AsRef<Path>>(path: P, specs: &ItemsSpec) -> Result<()> {
-    let table = specs.views.keys().next().unwrap();
+    let table = if let Some(default_view) = &specs.default_view {
+        default_view
+    } else {
+        specs.views.keys().next().unwrap()
+    };
     let mut templates = Tera::default();
     templates.add_raw_template(
         "index.html.tera",

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -16,11 +16,13 @@ use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Derefable, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct ItemsSpec {
     #[serde(default, rename = "name")]
     pub(crate) report_name: String,
     pub(crate) datasets: HashMap<String, DatasetSpecs>,
     #[deref]
+    pub(crate) default_view: Option<String>,
     pub(crate) views: HashMap<String, ItemSpecs>,
 }
 
@@ -341,6 +343,7 @@ mod tests {
 
         let expected_config = ItemsSpec {
             datasets: HashMap::from([(String::from("table-a"), expected_dataset_spec)]),
+            default_view: None,
             views: HashMap::from([(String::from("table-a"), expected_table_spec)]),
             report_name: "my_report".to_string(),
         };
@@ -400,6 +403,7 @@ mod tests {
 
         let expected_config = ItemsSpec {
             datasets: HashMap::from([(String::from("table-a"), expected_dataset_spec)]),
+            default_view: Some("table-a".to_string()),
             views: HashMap::from([(String::from("plot-a"), expected_item_spec)]),
             report_name: "".to_string(),
         };
@@ -412,6 +416,7 @@ mod tests {
                 my-link:
                     column: test
                     view: other-table
+    default-view: table-a
     views:
         plot-a:
             dataset: table-a


### PR DESCRIPTION
This PR introduces a new keyword `default-view` that allows the user to specify a view that is shown when opening the index file.