### PR TITLE
fix: Do not show empty tick plots

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -190,15 +190,17 @@ function renderTickPlots{{ loop.index0 }}(ah, columns) {
             var id = `{{ title | slugify }}-${row}`;
             this.classList.add("plotcell");
             const div = document.createElement("div");
-            value = this.innerHTML;
-            this.innerHTML = "";
-            this.appendChild(div);
-            var data = [{"{{ title }}": value}];
-            var s = specs;
-            s.data = {};
-            s.data.values = data;
-            var opt = {"actions": false};
-            vegaEmbed(div, JSON.parse(JSON.stringify(s)), opt);
+            let value = this.innerHTML;
+            if (value != "") {
+                this.innerHTML = "";
+                this.appendChild(div);
+                var data = [{"{{ title }}": value}];
+                var s = specs;
+                s.data = {};
+                s.data.values = data;
+                var opt = {"actions": false};
+                vegaEmbed(div, JSON.parse(JSON.stringify(s)), opt);
+            }
             row++;
         }
     );
@@ -236,8 +238,8 @@ function colorizeColumn{{ loop.index0 }}(ah, columns) {
                     row++;
                     return;
                 }
-                value = this.innerHTML;
-                link = link_url.replaceAll("{value}", value);
+                let value = this.innerHTML;
+                let link = link_url.replaceAll("{value}", value);
                 for (column of columns) {
                 {% raw %}link = link.replaceAll(`{${column}}`, table_rows[row][column]);{% endraw %}
                 }


### PR DESCRIPTION
This PR makes datavzrd not show plots generated with `ticks` that do not have any value. Vega-Lite plots look like this which could be somehow confusing as discovered by @FelixMoelder:
<img width="161" alt="Bildschirmfoto 2022-03-29 um 12 50 59" src="https://user-images.githubusercontent.com/39430842/160595690-3ed0b218-9356-45cc-ae1f-8434319832aa.png">

Alternatively to not showing a plot at all we could also have an empty plot (i.e only the horizontal line). What do you think @johanneskoester? 

**Option A** *(No plot at all)*:
<img width="89" alt="Bildschirmfoto 2022-03-29 um 12 59 56" src="https://user-images.githubusercontent.com/39430842/160597220-abe51e56-0783-4d1a-9d27-b4b691cfbd30.png">
**Option B** *(Empty plot)*:
<img width="81" alt="Bildschirmfoto 2022-03-29 um 12 57 58" src="https://user-images.githubusercontent.com/39430842/160596870-66dc5171-6c53-4fba-bdfd-9101fcd88299.png">

 