### PR TITLE
feat: Add ellipsis keyword

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -56,6 +56,8 @@ views:
   movies:
     dataset: movies
     render-table:
+      Genre:
+        ellipsis: 15
       imdbID:
         link-to-url: "https://www.imdb.com/title/{value}/"
       Title:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ views:
 | custom                      | Applies the given js function to render column content. The parameters of the function are similar to the ones defined [here](https://bootstrap-table.com/docs/api/column-options/#formatter) |         |                 |
 | [custom-plot](#custom-plot) | Renders a custom vega-lite plot to the corresponding table cell                                                                                                                               |         |                 |
 | [plot](#plot)               | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell                                                                                                           |         |                 |
+| ellipsis                    | Shortens values to the first *n* given characters with the rest hidden behind a popover                                                                                                       |         |                 |
 | optional                    | Allows to have a column specified in render-table that is actually not present.                                                                                                               | false   | true, false     |
 | display-mode                | Allows to have a column only in [detail view](https://examples.bootstrap-table.com/#options/detail-view.html#view-source) by setting this to `detail`.                                        | normal  | detail, normal  |
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -332,6 +332,12 @@ fn render_table_javascript<P: AsRef<Path>>(
         })
         .collect();
 
+    let ellipses: HashMap<String, u32> = render_columns
+        .iter()
+        .filter(|(_, k)| k.ellipsis.is_some())
+        .map(|(t, spec)| (t.to_string(), spec.ellipsis.unwrap()))
+        .collect();
+
     let mut display_modes: HashMap<String, String> = titles
         .iter()
         .map(|t| (t.to_string(), "normal".to_string()))
@@ -363,6 +369,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("custom_plots", &custom_plots);
     context.insert("tick_plots", &tick_plots);
     context.insert("heatmaps", &heatmaps);
+    context.insert("ellipses", &ellipses);
     context.insert("display_modes", &display_modes);
     context.insert("detail_mode", &detail_mode);
     context.insert("link_urls", &link_urls);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -197,6 +197,8 @@ pub(crate) struct RenderColumnSpec {
     pub(crate) plot: Option<PlotSpec>,
     #[serde(default)]
     pub(crate) custom_plot: Option<CustomPlot>,
+    #[serde(default)]
+    pub(crate) ellipsis: Option<u32>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -320,6 +322,7 @@ mod tests {
             link_to_url: Some(String::from("https://www.rust-lang.org")),
             plot: None,
             custom_plot: None,
+            ellipsis: None,
         };
 
         let expected_dataset_spec = DatasetSpecs {
@@ -447,6 +450,7 @@ mod tests {
             link_to_url: None,
             plot: None,
             custom_plot: None,
+            ellipsis: None,
         };
         assert_eq!(
             oscar_config.get("oscar_no").unwrap().to_owned(),

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -121,6 +121,10 @@ $(document).ready(function() {
         colorizeColumn{{ loop.index0 }}(additional_headers.length, displayed_columns);
     {% endfor %}
 
+    {% for title, ellipsis in ellipses %}
+        shortenColumn{{ loop.index0 }}(additional_headers.length, displayed_columns);
+    {% endfor %}
+
 let to_be_highlighted = parseInt(window.location.href.toString().split("highlight=").pop(), 10) + additional_headers.length;
     let rows = $("table > tbody > tr");
     rows.each(function() {
@@ -225,6 +229,26 @@ function colorizeColumn{{ loop.index0 }}(ah, columns) {
         }
     );
 }
+{% endfor %}
+
+{% for title, ellipsis in ellipses %}
+    function shortenColumn{{ loop.index0 }}(ah, columns) {
+        let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
+        let row = 0;
+        $(`table > tbody > tr td:nth-child(${index})`).each(
+            function() {
+                if (row < ah) {
+                    row++;
+                    return;
+                }
+                value = this.innerHTML;
+                if (value.length > {{ ellipsis }}) {
+                    this.innerHTML = `${value.substring(0,{{ ellipsis }})}<a tabindex="0" role="button" href="#" data-toggle="popover" data-trigger="focus" data-html='true' data-content='<div style="overflow: auto; max-height: 30vh; max-width: 25vw;">${value}</div>'>...</a>`;
+                }
+                row++;
+            }
+        );
+    }
 {% endfor %}
 
 {% for title, link_url in link_urls %}


### PR DESCRIPTION
This PR adds keyword `ellipsis` to datavzrd that allows the user to limit values in tables to the first *n* characters.

Example:
```yaml
views:
  table-a:
    dataset: my-dataset
    render-table:
      column-with-long-values:
        ellipsis: 30 # only shows the first 30 characters with the rest accessible via a popover
```