### PR TITLE
feat: Add new keyword hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ views:
 | pin-columns                   | Number of columns that are fixed to the left side of the table and therefore always visible                                                | 0       |
 | [render-table](#render-table) | Configuration of individual column rendering                                                                                               |         |
 | [render-plot](#render-plot)   | Configuration of a single plot                                                                                                             |         |
+| hidden                        | Whether or not the view is shown in the menu navigation                                                                                    | false   |
 
 ### render-table 
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -134,6 +134,7 @@ impl Renderer for ItemRenderer {
                             &linked_tables,
                             dataset.links.as_ref().unwrap(),
                             &self.specs.report_name,
+                            &self.specs.views,
                         )?;
                     }
                     render_table_javascript(
@@ -187,6 +188,7 @@ fn render_page<P: AsRef<Path>>(
     linked_tables: &LinkedTable,
     links: &HashMap<String, LinkSpec>,
     report_name: &str,
+    views: &HashMap<String, ItemSpecs>,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -220,7 +222,7 @@ fn render_page<P: AsRef<Path>>(
     context.insert("current_page", &page_index);
     context.insert("pages", &pages);
     context.insert("description", &description);
-    context.insert("tables", tables);
+    context.insert("tables", &tables.iter().filter(|t| !views.get(*t).unwrap().hidden ).collect_vec());
     context.insert("name", name);
     context.insert("report_name", report_name);
     context.insert("time", &local.format("%a %b %e %T %Y").to_string());

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -222,7 +222,13 @@ fn render_page<P: AsRef<Path>>(
     context.insert("current_page", &page_index);
     context.insert("pages", &pages);
     context.insert("description", &description);
-    context.insert("tables", &tables.iter().filter(|t| !views.get(*t).unwrap().hidden ).collect_vec());
+    context.insert(
+        "tables",
+        &tables
+            .iter()
+            .filter(|t| !views.get(*t).unwrap().hidden)
+            .collect_vec(),
+    );
     context.insert("name", name);
     context.insert("report_name", report_name);
     context.insert("time", &local.format("%a %b %e %T %Y").to_string());

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -135,6 +135,8 @@ pub(crate) struct DatasetSpecs {
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct ItemSpecs {
+    #[serde(default)]
+    pub(crate) hidden: bool,
     pub(crate) dataset: String,
     #[serde(default = "default_page_size")]
     pub(crate) page_size: usize,
@@ -396,6 +398,7 @@ mod tests {
         };
 
         let expected_table_spec = ItemSpecs {
+            hidden: false,
             dataset: "table-a".to_string(),
             page_size: 100,
             pin_columns: 1,
@@ -459,6 +462,7 @@ mod tests {
         };
 
         let expected_item_spec = ItemSpecs {
+            hidden: false,
             dataset: "table-a".to_string(),
             page_size: 100,
             pin_columns: 0,


### PR DESCRIPTION
This PR adds a new keyword `hidden` that allows users to hide specific views and only access them via linkouts.