### PR TITLE
fix!: Remove pin-columns keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ views:
               - red
   gene-mycn-plot:
     dataset: gene-mycn
-    pin-columns: 3
     render-plot:
       spec: |
         {
@@ -133,7 +132,6 @@ views:
 | desc                          | A description that will be shown in the report. [Markdown](https://github.github.com/gfm/) is allowed and will be rendered to proper HTML. |         |
 | dataset                       | The name of the corresponding dataset to this view defined in [datasets](#datasets)                                                        |         |
 | page-size                     | Number of rows per page                                                                                                                    | 100     |
-| pin-columns                   | Number of columns that are fixed to the left side of the table and therefore always visible                                                | 0       |
 | [render-table](#render-table) | Configuration of individual column rendering                                                                                               |         |
 | [render-plot](#render-plot)   | Configuration of a single plot                                                                                                             |         |
 | hidden                        | Whether or not the view is shown in the menu navigation                                                                                    | false   |

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -144,7 +144,6 @@ impl Renderer for ItemRenderer {
                         dataset.separator,
                         table_specs,
                         additional_headers,
-                        table.pin_columns,
                     )?;
                     render_plots(
                         &out_path,
@@ -253,7 +252,6 @@ fn render_table_javascript<P: AsRef<Path>>(
     separator: char,
     render_columns: &HashMap<String, RenderColumnSpec>,
     additional_headers: Option<Vec<StringRecord>>,
-    pin_columns: usize,
 ) -> Result<()> {
     let mut templates = Tera::default();
     templates.add_raw_template(
@@ -382,7 +380,6 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("detail_mode", &detail_mode);
     context.insert("link_urls", &link_urls);
     context.insert("num", &numeric);
-    context.insert("pin_columns", &pin_columns);
 
     let file_path = Path::new(output_path.as_ref()).join(Path::new("table").with_extension("js"));
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -209,8 +209,6 @@ pub(crate) struct ItemSpecs {
     pub(crate) dataset: String,
     #[serde(default = "default_page_size")]
     pub(crate) page_size: usize,
-    #[serde(default)]
-    pub(crate) pin_columns: usize,
     #[serde(rename = "desc")]
     pub(crate) description: Option<String>,
     #[serde(default = "default_render_table")]
@@ -510,7 +508,6 @@ mod tests {
             hidden: false,
             dataset: "table-a".to_string(),
             page_size: 100,
-            pin_columns: 1,
             description: None,
             render_table: Some(HashMap::from([(
                 String::from("x"),
@@ -535,7 +532,6 @@ mod tests {
         table-a:
             dataset: table-a
             page-size: 100
-            pin-columns: 1
             render-table:
                 x:
                     link-to-url: https://www.rust-lang.org
@@ -574,7 +570,6 @@ mod tests {
             hidden: false,
             dataset: "table-a".to_string(),
             page_size: 100,
-            pin_columns: 0,
             description: Some("my table".parse().unwrap()),
             render_table: default_render_table(),
             render_plot: Some(expected_render_plot),

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -28,22 +28,13 @@ $(document).ready(function() {
         formatter: function(value, row, index, field) { if (format["{{ title }}"] != undefined){ return format["{{ title }}"](value, row, index, field) } else { return value } }{% endif %}
     }{% if not loop.last %},{% endif %}{% endif %}{% endfor %}];
 
-    var fixed_right = 0;
-    var fixed = false;
-
-    if (linkouts != null) {
-        bs_table_cols.push({field: 'linkouts', title: '', formatter: function(value){ return value }});
-        fixed_right = 1;
-    }
+    bs_table_cols.push({field: 'linkouts', title: '', formatter: function(value){ return value }});
 
     $('#table').bootstrapTable({
         height: he,
         columns: bs_table_cols,
         data: [],
         {% if detail_mode %}detailView: true, detailFormatter: "detailFormatter",{% endif %}
-        fixedColumns: true,
-        fixedRightNumber: fixed_right,
-        fixedNumber: {{ pin_columns }}
     })
 
     let additional_headers = [{% if additional_headers %}{% for ah in additional_headers %}{{ "{" }}{% for title in titles %}"{{ title }}":"<b>{{ ah[title] }}</b>"{% if not loop.last %},{% endif %}{% endfor %}{{ "}" }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}];


### PR DESCRIPTION
This PR removes the keyword `pin-columns` due a problem with bootstrap-table.