### PR TITLE
feat: Allow missing values in other tables with keyword optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ datasets:
       gene expression:
         column: gene
         table-row: table-b/gene
+        optional: true
   table-b:
     path: table-b.csv
     separator: ;
@@ -168,11 +169,12 @@ views:
 
 `links` can configure linkouts between multiple items.
 
-| keyword   | explanation                                                                                                      |
-| --------- | ---------------------------------------------------------------------------------------------------------------- |
-| column    | The column that contains the value used for the linkout                                                          |
-| table-row | Renders as a linkout to the other table highlighting the row in which the gene column has the same value as here |
-| view      | Renders as a link to the given view                                                                              |
+| keyword   | explanation                                                                                                      | default |
+| --------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| column    | The column that contains the value used for the linkout                                                          |         |
+| table-row | Renders as a linkout to the other table highlighting the row in which the gene column has the same value as here |         |
+| view      | Renders as a link to the given view                                                                              |         |
+| optional  | Allows missing values in linked tables                                                                           | false   |
 
 ### custom-plot
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -731,11 +731,15 @@ fn render_linkouts(
             let linked_value = match linked_values.index.get(&row[index]) {
                 Some(value) => value,
                 None => {
-                    bail!(TableLinkingError::NotFound {
-                        not_found: row[index].to_string(),
-                        column: linked_column.to_string(),
-                        table: table.to_string(),
-                    })
+                    if !link_specs.optional {
+                        bail!(TableLinkingError::NotFound {
+                            not_found: row[index].to_string(),
+                            column: linked_column.to_string(),
+                            table: table.to_string(),
+                        })
+                    } else {
+                        continue;
+                    }
                 }
             };
             linkouts.push(Linkout {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -377,6 +377,8 @@ pub(crate) struct LinkSpec {
     pub(crate) view: Option<String>,
     #[serde(default)]
     pub(crate) table_row: Option<String>,
+    #[serde(default)]
+    pub(crate) optional: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -581,6 +583,7 @@ mod tests {
                 column: "test".to_string(),
                 view: Some("other-table".to_string()),
                 table_row: None,
+                optional: false,
             },
         )]);
 


### PR DESCRIPTION
This PR allows missing values in other tables with keyword `optional`. This should solve the problem we talked about @FelixMoelder ☺️