### PR TITLE
docs: Fix example dataset

### DIFF
--- a/.examples/data/movies.csv
+++ b/.examples/data/movies.csv
@@ -1,5 +1,5 @@
 Title,Year,Rated,Released,Runtime,Genre,Director,imdbRating,imdbID
-7th Heaven,1996–2007,TV-G,26 Aug 1996,60 min,"Comedy, Drama, Family",N/A,5.2,tt0115083
+7th Heaven,1927,Unrated,6 May 1927,110 min,"Drama",Frank Borzage,7.6,tt0018379
 Coquette,1929,Unrated,06 Apr 1929,76 min,"Drama, Romance",Sam Taylor,5.7,tt0019788
 The Divorcee,1930,Passed,19 Apr 1930,84 min,"Romance, Drama",Robert Z. Leonard,6.7,tt0020827
 Min and Bill,1930,Passed,29 Nov 1930,69 min,"Comedy, Drama",George W. Hill,6.8,tt0021148


### PR DESCRIPTION
Just a small fix for the example movie dataset that should fix that the year column is not detected as numeric.