### PR TITLE
feat: New keyword aux-domain-columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,21 +200,23 @@ views:
 
 `ticks` defines the attributes of a [tick-plot](https://vega.github.io/vega-lite/docs/tick.html) for numeric values.
 
-| keyword | explanation                                                                                                                       |
-| ------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| scale   | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot                                            |
-| domain  | Defines the domain of the tick plot. If not present datavzrd will automatically use the minimum and maximum values for the domain |
+| keyword            | explanation                                                                                                                       |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the tick plot                                            |
+| domain             | Defines the domain of the tick plot. If not present datavzrd will automatically use the minimum and maximum values for the domain |
+| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the tick plot.                |
 
 ### heatmap
 
 `heatmap` defines the attributes of a heatmap for numeric or nominal values.
 
-| keyword      | explanation                                                                                                         |
-| ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| scale        | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                |
-| color-scheme | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values |
-| range        | Defines the color range of the heatmap as a list                                                                    |
-| domain       | Defines the domain of the heatmap as a list                                                                         |
+| keyword            | explanation                                                                                                                                        |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                                               |
+| color-scheme       | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values                                |
+| range              | Defines the color range of the heatmap as a list                                                                                                   |
+| domain             | Defines the domain of the heatmap as a list                                                                                                        |
+| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Only allowed for numeric columns. |
 
 ## Authors
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -419,11 +419,14 @@ pub(crate) struct PlotSpec {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct TickPlot {
     #[serde(default, rename = "scale")]
     pub(crate) scale_type: String,
     #[serde(default)]
     pub(crate) domain: Option<Vec<f32>>,
+    #[serde(default)]
+    pub(crate) aux_domain_columns: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -437,9 +440,11 @@ pub(crate) struct Heatmap {
     color_range: Vec<String>,
     #[serde(default)]
     pub(crate) domain: Option<Vec<String>>,
+    #[serde(default)]
+    pub(crate) aux_domain_columns: Option<Vec<String>>,
 }
 
-static SCALE_TYPES: [&'static str; 14] = [
+static SCALE_TYPES: [&str; 14] = [
     "linear",
     "pow",
     "sqrt",


### PR DESCRIPTION
This PR introduces a new keyword `aux-domain-columns` that allows to specify a list of other columns that will be additionally used to determine the domain of the tick plot and therefore closes #102.