### PR TITLE
fix: Limit maximum characters in axis labels for brush filters

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -138,7 +138,9 @@ $(document).ready(function() {
             }
             let min = Math.min(...values);
             let max = Math.max(...values);
+            let legend_tick_length = min.toString().length + max.toString().length;
             var s = tick_brush_specs;
+            s.encoding.x.axis.labels = legend_tick_length < 8;
             s.data.values = plot_data;
             s.name = title;
             s.encoding.x.axis.values = [min, max];


### PR DESCRIPTION
This PR limits the amount of characters in axis labels for brush filters so they don't overlap each other when too large.