### PR TITLE
fix: Use tick domain for filter brush if present

### DIFF
--- a/.examples/example-config.yaml
+++ b/.examples/example-config.yaml
@@ -32,6 +32,9 @@ views:
         plot:
           ticks:
             scale: linear
+            domain:
+              - 20
+              - 100
       name:
         link-to-url: "https://lmgtfy.app/?q=Is {name} in {movie}?"
       movie:

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -313,6 +313,37 @@ fn render_table_javascript<P: AsRef<Path>>(
         })
         .collect();
 
+    let brush_domains: HashMap<String, Vec<f32>> = render_columns
+        .iter()
+        .filter(|(_, k)| k.plot.is_some())
+        .filter(|(_, k)| k.plot.as_ref().unwrap().tick_plot.is_some())
+        .filter(|(_, k)| {
+            k.plot
+                .as_ref()
+                .unwrap()
+                .tick_plot
+                .as_ref()
+                .unwrap()
+                .domain
+                .is_some()
+        })
+        .map(|(title, k)| {
+            (
+                title.to_string(),
+                k.plot
+                    .as_ref()
+                    .unwrap()
+                    .tick_plot
+                    .as_ref()
+                    .unwrap()
+                    .domain
+                    .as_ref()
+                    .unwrap()
+                    .to_vec(),
+            )
+        })
+        .collect();
+
     let heatmaps: HashMap<String, (&Heatmap, String)> = render_columns
         .iter()
         .filter(|(_, k)| k.plot.is_some())
@@ -388,6 +419,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     context.insert("detail_mode", &detail_mode);
     context.insert("link_urls", &link_urls);
     context.insert("num", &numeric);
+    context.insert("brush_domains", &json!(brush_domains).to_string());
     context.insert("is_single_page", &is_single_page);
 
     let file_path = Path::new(output_path.as_ref()).join(Path::new("table").with_extension("js"));

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -126,6 +126,7 @@ $(document).ready(function() {
         "config": {"axis": {"grid": false},"background": null, "style": {"cell": {"stroke": "transparent"}}, "tick": {"thickness": 0.5, "bandSize": 6}}
         };
 
+    let brush_domains = {{ brush_domains }};
     let tick_brush = 0;
     for (title of displayed_columns) {
         let index = tick_brush + 1{% if detail_mode %} + 1{% endif %};
@@ -138,12 +139,17 @@ $(document).ready(function() {
             }
             let min = Math.min(...values);
             let max = Math.max(...values);
+            if (brush_domains[title] != undefined) {
+                min = brush_domains[title][0];
+                max = brush_domains[title][1];
+            }
             let legend_tick_length = min.toString().length + max.toString().length;
             var s = tick_brush_specs;
             s.encoding.x.axis.labels = legend_tick_length < 8;
             s.data.values = plot_data;
             s.name = title;
             s.encoding.x.axis.values = [min, max];
+            s.encoding.x.scale.domain = [min, max];
             $(`table > thead > tr th:nth-child(${index})`).append(`<div id="brush-${tick_brush}"></div>`);
             var opt = {"actions": false};
             vegaEmbed(`#brush-${tick_brush}`, JSON.parse(JSON.stringify(s)), opt).then(({spec, view}) => {


### PR DESCRIPTION
This PR makes datavzrd use the tick domain for filter brushes if present.