### PR TITLE
fix: Include aux domains in filter brush domain

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -128,6 +128,7 @@ $(document).ready(function() {
         };
 
     let brush_domains = {{ brush_domains }};
+    let aux_domains = {{ aux_domains }};
 
    function render_brush_plots(reset) {
    let tick_brush = 0;
@@ -145,6 +146,15 @@ $(document).ready(function() {
                if (brush_domains[title] != undefined) {
                    min = brush_domains[title][0];
                    max = brush_domains[title][1];
+               } else if (aux_domains[title] != undefined) {
+                   aux_values = [min, max];
+                   for (col of aux_domains[title]) {
+                        for (row of table_rows) {
+                            aux_values.push(parseFloat(row[col]));
+                        }
+                   }
+                   min = Math.min(...aux_values);
+                   max = Math.max(...aux_values);
                }
                if (Number.isInteger(min)) {
                    min = parseInt(min.toString());


### PR DESCRIPTION
This PR adjusts datavzrds filter brush domains according to given values in `aux-domain-columns` columns.