### PR TITLE
feat: Allow aux-domain-columns for non-numeric column heatmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ views:
 | color-scheme       | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values                                                                                                                                                |
 | range              | Defines the color range of the heatmap as a list                                                                                                                                                                                                                   |
 | domain             | Defines the domain of the heatmap as a list                                                                                                                                                                                                                        |
-| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Only allowed for numeric columns. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported. |
+| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported.                                   |
 
 ## Authors
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use lz_str::compress_to_utf16;
 use serde::Serialize;
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -641,13 +641,43 @@ fn get_column_domain(
         .map(|s| s.iter().position(|t| t == title).unwrap())?;
 
     match heatmap.scale_type.as_str() {
-        "ordinal" => Ok(json!(reader
-            .records()
-            .map(|r| r.unwrap())
-            .map(|r| r.get(column_index).unwrap().to_owned())
-            .unique()
-            .collect_vec())
-        .to_string()),
+        "ordinal" => {
+            if let Some(aux_domain_columns) = &heatmap.aux_domain_columns.0 {
+                let columns = aux_domain_columns
+                    .iter()
+                    .map(|s| s.to_string())
+                    .chain(vec![title.to_string()].into_iter())
+                    .collect_vec();
+                let column_indexes: HashSet<_> = reader.headers().map(|s| {
+                    s.iter()
+                        .enumerate()
+                        .filter(|(_, title)| columns.contains(&title.to_string()))
+                        .map(|(index, _)| index)
+                        .collect()
+                })?;
+                Ok(json!(reader
+                    .records()
+                    .map(|r| r.unwrap())
+                    .map(|r| r
+                        .iter()
+                        .enumerate()
+                        .filter(|(index, _)| column_indexes.contains(index))
+                        .map(|(_, value)| value.to_string())
+                        .collect_vec())
+                    .flatten()
+                    .unique()
+                    .collect_vec())
+                .to_string())
+            } else {
+                Ok(json!(reader
+                    .records()
+                    .map(|r| r.unwrap())
+                    .map(|r| r.get(column_index).unwrap().to_owned())
+                    .unique()
+                    .collect_vec())
+                .to_string())
+            }
+        }
         _ => {
             if let Some(aux_domain_columns) = &heatmap.aux_domain_columns.0 {
                 let columns = aux_domain_columns


### PR DESCRIPTION
This PR allows using the `aux-domain-columns` keyword for non-numeric column heatmaps. Therefore this closes #132.