### PR TITLE
fix: Fix column highlighting for firefox

### DIFF
--- a/static/datavzrd.css
+++ b/static/datavzrd.css
@@ -49,6 +49,8 @@ td {
     padding-bottom: 0;
     padding-top: 0;
     padding-right: 0.5rem;
+    /* Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=688556 see https://github.com/koesterlab/datavzrd/issues/144 */
+    background-clip: padding-box;
 }
 
 .table td.plotcell {


### PR DESCRIPTION
This PR fixes #144 by adding a known workaround for [a well-known firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=688556) that overwrites borders with the background color.