### PR TITLE
fix: Remove detail view when columns are hidden

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -441,7 +441,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     }
     let detail_mode = display_modes
         .iter()
-        .filter(|(_, mode)| *mode != "normal")
+        .filter(|(_, mode)| *mode == "detail")
         .count()
         > 0;
 


### PR DESCRIPTION
This PR only adds the `+` sign to the beginning of the table rows if columns with `display-mode: detail` exist and therefore fixes #157 by removing the `+` for the table when only columns with `display-mode: hidden` or `display-mode: normal` exist. 