### PR TITLE
feat: Add new render-html keyword and allow integration of aux-libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ views:
 
 `max-in-memory-rows` defines the threshold for the maximum number of rows in memory. If the given dataset exceeds the threshold the data will be split across multiple pages and their html files. Defaults to 1000 rows.
 
-| keyword         | explanation                                                                                   | default |
-| --------------- |-----------------------------------------------------------------------------------------------| ------- |
-| path            | The path of the CSV/TSV file                                                                  |         |
-| separator       | The delimiter of the file                                                                     | ,       |
-| header-rows     | Number of header-rows of the file                                                             | 1       |
-| [links](#links) | Configuration linking between items                                                           |         |
-| aux-libraries   | Allows to add one or more js libraries via cdn links for usage in [render-html](#render-html) |         |
+| keyword          | explanation                                                                                                                                                      | default |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
+| path             | The path of the CSV/TSV file                                                                                                                                     |         |
+| separator        | The delimiter of the file                                                                                                                                        | ,       |
+| header-rows      | Number of header-rows of the file                                                                                                                                | 1       |
+| [links](#links)  | Configuration linking between items                                                                                                                              |         |
+| aux-libraries    | Allows to add one or more js libraries via cdn links for usage in [render-html](#render-html). The keyword expects a list of urls that link to the js libraries. |         |
 
 ### views
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ views:
 
 `max-in-memory-rows` defines the threshold for the maximum number of rows in memory. If the given dataset exceeds the threshold the data will be split across multiple pages and their html files. Defaults to 1000 rows.
 
-| keyword         | explanation                         | default |
-| --------------- | ----------------------------------- | ------- |
-| path            | The path of the CSV/TSV file        |         |
-| separator       | The delimiter of the file           | ,       |
-| header-rows     | Number of header-rows of the file   | 1       |
-| [links](#links) | Configuration linking between items |         |
+| keyword         | explanation                                                                                   | default |
+| --------------- |-----------------------------------------------------------------------------------------------| ------- |
+| path            | The path of the CSV/TSV file                                                                  |         |
+| separator       | The delimiter of the file                                                                     | ,       |
+| header-rows     | Number of header-rows of the file                                                             | 1       |
+| [links](#links) | Configuration linking between items                                                           |         |
+| aux-libraries   | Allows to add one or more js libraries via cdn links for usage in [render-html](#render-html) |         |
 
 ### views
 
@@ -140,6 +141,7 @@ views:
 | page-size                     | Number of rows per page                                                                                                                                                                                                                            | 100     |
 | [render-table](#render-table) | Configuration of individual column rendering                                                                                                                                                                                                       |         |
 | [render-plot](#render-plot)   | Configuration of a single plot                                                                                                                                                                                                                     |         |
+| [render-html](#render-html)   | Configuration of a custom html view                                                                                                                                                                                                                |         |
 | hidden                        | Whether or not the view is shown in the menu navigation                                                                                                                                                                                            | false   |
 | max-in-memory-rows            | Overwrites the global settings for [max-in-memory-rows](#max-in-memory-rows)                                                                                                                                                                       |         |
 
@@ -165,6 +167,14 @@ views:
 | --------- | -------------------------------------------------------------------------------------------------- |
 | spec      | A schema for a vega lite plot that will be rendered to a single view                               |
 | spec-path | The path to a file containing a schema for a vega lite plot that will be rendered to a single view |
+
+### render-html
+
+`render-html` contains individual configurations for generating a single custom view where a variable `data` with the dataset in json format that can be accessed in the given js file. The rendered view contains a `<div id="canvas">` that can then be manipulated with the given script.
+
+| keyword     | explanation                                                                                                 |
+|-------------|-------------------------------------------------------------------------------------------------------------|
+| script-path | A path to a js file that has access to the dataset and can manipulate the given canvas of the rendered view |
 
 ### links
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ views:
 
 ### render-html
 
-`render-html` contains individual configurations for generating a single custom view where a variable `data` with the dataset in json format that can be accessed in the given js file. The rendered view contains a `<div id="canvas">` that can then be manipulated with the given script.
+`render-html` contains individual configurations for generating a single custom view where a global variable `data` with the dataset in json format can be accessed in the given js file. The rendered view contains a `<div id="canvas">` that can then be manipulated with the given script. By default, the div uses the full width and centers its contents. Of course, the divs CSS can be overwritten via Javascript. jQuery is already available, any other necessary Javascript libraries can be loaded via [aux-libraries](#aux-libraries).
 
 | keyword     | explanation                                                                                                 |
 |-------------|-------------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -121,13 +121,16 @@ views:
 
 `max-in-memory-rows` defines the threshold for the maximum number of rows in memory. If the given dataset exceeds the threshold the data will be split across multiple pages and their html files. Defaults to 1000 rows.
 
+### aux-libraries
+
+`aux-libraries` allows to add one or more js libraries via cdn links for usage in [render-html](#render-html). The keyword expects a list of urls that link to the js libraries.
+
 | keyword          | explanation                                                                                                                                                      | default |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- |
 | path             | The path of the CSV/TSV file                                                                                                                                     |         |
 | separator        | The delimiter of the file                                                                                                                                        | ,       |
 | header-rows      | Number of header-rows of the file                                                                                                                                | 1       |
 | [links](#links)  | Configuration linking between items                                                                                                                              |         |
-| aux-libraries    | Allows to add one or more js libraries via cdn links for usage in [render-html](#render-html). The keyword expects a list of urls that link to the js libraries. |         |
 
 ### views
 

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -113,7 +113,7 @@ mod tests {
             default_view: Some("my-view".to_string()),
             max_in_memory_rows: 1000,
             views: Default::default(),
-            aux_libraries: None
+            aux_libraries: None,
         };
         render_index_file(Path::new("/tmp"), &spec).unwrap();
         let rendered_file_content = fs::read_to_string("/tmp/index.html")

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -113,6 +113,7 @@ mod tests {
             default_view: Some("my-view".to_string()),
             max_in_memory_rows: 1000,
             views: Default::default(),
+            aux_libraries: None
         };
         render_index_file(Path::new("/tmp"), &spec).unwrap();
         let rendered_file_content = fs::read_to_string("/tmp/index.html")

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -33,6 +33,7 @@ pub(crate) struct ItemsSpec {
     #[serde(default = "default_single_page_threshold")]
     pub(crate) max_in_memory_rows: usize,
     pub(crate) views: HashMap<String, ItemSpecs>,
+    pub(crate) aux_libraries: Option<Vec<String>>,
 }
 
 impl ItemsSpec {
@@ -255,6 +256,8 @@ pub(crate) struct ItemSpecs {
     #[serde(default)]
     pub(crate) render_plot: Option<RenderPlotSpec>,
     #[serde(default)]
+    pub(crate) render_html: Option<RenderHtmlSpec>,
+    #[serde(default)]
     pub(crate) max_in_memory_rows: Option<usize>,
 }
 
@@ -425,6 +428,12 @@ impl RenderPlotSpec {
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all(deserialize = "kebab-case"))]
+pub(crate) struct RenderHtmlSpec {
+    pub(crate) script_path: String,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(deserialize = "kebab-case"))]
 pub(crate) struct LinkSpec {
     #[serde(default)]
     pub(crate) column: String,
@@ -499,7 +508,7 @@ pub(crate) struct Heatmap {
     pub(crate) aux_domain_columns: AuxDomainColumns,
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuxDomainColumns(pub(crate) Option<Vec<String>>);
 
 impl AuxDomainColumns {
@@ -644,6 +653,7 @@ mod tests {
                 expected_render_columns,
             )])),
             render_plot: None,
+            render_html: None,
             max_in_memory_rows: None,
         };
 
@@ -653,6 +663,7 @@ mod tests {
             max_in_memory_rows: 1000,
             views: HashMap::from([(String::from("table-a"), expected_table_spec)]),
             report_name: "my_report".to_string(),
+            aux_libraries: None
         };
 
         let raw_config = r#"
@@ -707,6 +718,7 @@ mod tests {
             description: Some("my table".parse().unwrap()),
             render_table: default_render_table(),
             render_plot: Some(expected_render_plot),
+            render_html: None,
             max_in_memory_rows: None,
         };
 
@@ -716,6 +728,7 @@ mod tests {
             max_in_memory_rows: 1000,
             views: HashMap::from([(String::from("plot-a"), expected_item_spec)]),
             report_name: "".to_string(),
+            aux_libraries: None
         };
 
         let raw_config = r#"
@@ -995,6 +1008,7 @@ mod tests {
                 expected_render_columns,
             )])),
             render_plot: None,
+            render_html: None,
             max_in_memory_rows: None,
         };
 

--- a/templates/html.html.tera
+++ b/templates/html.html.tera
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>datavzrd report</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="../static/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="../static/bootstrap-table.min.css">
+    <link rel="stylesheet" type="text/css" href="../static/bootstrap-select.min.css">
+    <link rel="stylesheet" type="text/css" href="../static/datavzrd.css">
+</head>
+
+<body>
+<script src="../static/jquery.min.js"></script>
+<script src="../static/bootstrap.bundle.min.js"></script>
+<script src="../static/bootstrap-table.min.js"></script>
+<script src="../static/bootstrap-select.min.js"></script>
+<script src="../static/vega.min.js"></script>
+<script src="../static/vega-lite.min.js"></script>
+<script src="../static/vega-embed.min.js"></script>
+<script src="../static/lz-string.min.js"></script>
+<script src="../static/showdown.min.js"></script>
+{% if aux_libraries %}
+{% for library in aux_libraries %}
+<script src="{{ library }}"></script>
+{% endfor %}
+{% endif %}
+
+<nav class="navbar navbar-expand navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">datavzrd</a>
+    <div class="collapse navbar-collapse" id="navbarText">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools/blob/master/CHANGELOG.md">{{ version }}</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="https://github.com/rust-bio/rust-bio-tools">github</a>
+            </li>
+        </ul>
+        <span class="navbar-text">
+            created {{ time }}
+        </span>
+    </div>
+</nav>
+<nav class="navbar navbar-expand navbar-light bg-light">
+    <div class="collapse navbar-collapse" id="navbarText2">
+        <ul class="navbar-nav mr-auto">
+            <li><a href="#">{{ name }}</a></li>
+        </ul>
+        <span class="pull-right">
+            {% if description %}
+            <div class="btn-group">
+                <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseDescription" aria-expanded="false" aria-controls="collapseDescription">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle-fill" viewBox="0 0 16 16">
+                        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+                    </svg>
+                </button>
+            </div>
+            {% endif %}
+            <select id="view-selection" title="views" data-width="fit" onchange="location = this.value;" data-live-search-placeholder="Filter..." data-dropdown-align-right="true" class="selectpicker" data-style="btn-primary" data-live-search="true">
+                {% if default_view %}
+                <option value="../{{ default_view }}/index_1.html">{{ default_view }}</option>
+                {% endif %}
+                {% for table in tables | sort %}
+                <option value="../{{ table }}/index_1.html">{{ table }}</option>
+                {% endfor %}
+            </select>
+        </span>
+    </div>
+</nav>
+<div class="container-fluid">
+    {% if description %}
+    <script>
+        $(document).ready(function() {
+            var innerDescription = document.getElementById('innerDescription');
+            var converter = new showdown.Converter();
+            converter.setFlavor('github');
+            innerDescription.innerHTML = converter.makeHtml(innerDescription.dataset.markdown);
+        });
+    </script>
+    <div class="row" style="margin-top: 15px;">
+        <div class="col-md-12">
+            <div class="collapse" id="collapseDescription">
+                <div class="card card-body" id="innerDescription" data-markdown="{{ description | escape }}">
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    <script>
+    var data = {{ data | safe }};
+    {{ script | safe}}
+    </script>
+    <div class="row">
+        <div class="col-md-12 d-flex justify-content-center" id="canvas"></div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds new render-html keyword and allows integration of aux-libraries as described in #161 and therefore closes #161.