### PR TITLE
feat: Allow rendering custom content into any heatmap cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,14 @@ views:
 
 `heatmap` defines the attributes of a heatmap for numeric or nominal values.
 
-| keyword            | explanation                                                                                                                                                                                                                                                        |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scale              | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                                                                                                                                                               |
-| color-scheme       | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values                                                                                                                                                |
-| range              | Defines the color range of the heatmap as a list                                                                                                                                                                                                                   |
-| domain             | Defines the domain of the heatmap as a list                                                                                                                                                                                                                        |
-| aux-domain-columns | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported.                                   |
+| keyword             | explanation                                                                                                                                                                                                                     |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scale               | Defines the [scale](https://vega.github.io/vega-lite/docs/scale.html) of the heatmap                                                                                                                                            |
+| color-scheme        | Defines the [color-scheme](https://vega.github.io/vega/docs/schemes/#categorical) of the heatmap for nominal values                                                                                                             |
+| range               | Defines the color range of the heatmap as a list                                                                                                                                                                                |
+| domain              | Defines the domain of the heatmap as a list                                                                                                                                                                                     |
+| aux-domain-columns  | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported. |
+| custom-content      | Allows to render custom content into any heatmap cell. Requires a function(value, row) that returns the value that will be used for the heatmap.                                                                                | 
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ views:
 | range               | Defines the color range of the heatmap as a list                                                                                                                                                                                |
 | domain              | Defines the domain of the heatmap as a list                                                                                                                                                                                     |
 | aux-domain-columns  | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported. |
-| custom-content      | Allows to render custom content into any heatmap cell. Requires a `function(value, row)` that returns the value that will be used for the heatmap.                                                                                | 
+| custom-content      | Allows to render custom content into any heatmap cell (while using the actual cell content for the heatmap color). Requires a `function(value, row)` that returns the text value that will be displayed in the cell.                                                                                | 
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ views:
 | range               | Defines the color range of the heatmap as a list                                                                                                                                                                                |
 | domain              | Defines the domain of the heatmap as a list                                                                                                                                                                                     |
 | aux-domain-columns  | Allows to specify a list of other columns that will be additionally used to determine the domain of the heatmap. Regular expression (e.g. `regex('prob:.+')` for matching all columns starting with `prob:`) are also supported. |
-| custom-content      | Allows to render custom content into any heatmap cell. Requires a function(value, row) that returns the value that will be used for the heatmap.                                                                                | 
+| custom-content      | Allows to render custom content into any heatmap cell. Requires a `function(value, row)` that returns the value that will be used for the heatmap.                                                                                | 
 
 ## Authors
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -373,6 +373,7 @@ fn render_table_javascript<P: AsRef<Path>>(
                 .filter(|(title, _)| *numeric.get(&title.to_string()).unwrap_or(&false))
                 .filter_map(|(title, k)| k.plot.as_ref().map(|plot| (title, plot)))
                 .filter_map(|(title, k)| k.heatmap.as_ref().map(|heatmap| (title, heatmap)))
+                .filter(|(_, k)| k.custom_content.is_none())
                 .filter_map(|(title, k)| k.domain.as_ref().map(|domain| (title, domain)))
                 .map(|(title, k)| {
                     (

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -509,6 +509,8 @@ pub(crate) struct Heatmap {
     pub(crate) domain: Option<Vec<String>>,
     #[serde(default)]
     pub(crate) aux_domain_columns: AuxDomainColumns,
+    #[serde(default)]
+    pub(crate) custom_content: Option<String>,
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -357,19 +357,25 @@ function renderDetailTickPlots{{ loop.index0 }}(value, div) {
 {% endfor %}
 
 {% for title, tuple in heatmaps %}
-function colorizeColumn{{ loop.index0 }}(ah, columns) {
+function colorizeColumn{{ loop.index0 }}(ah, columns, table_rows) {
     let detail_mode = columns.indexOf("{{ title }}") == -1;
     let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
     var {{ tuple.0.scale }} = vega.scale('{{ tuple.0.scale }}');
     var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.color_scheme %}vega.scheme('{{ tuple.0.color_scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
     let row = 0;
+    {% if tuple.0.custom_content %}
+    var custom_func = {{ tuple.0.custom_content }};
+    {% endif %}
     $(`table > tbody > tr td:nth-child(${index})`).each(
         function() {
             if (row < ah) {
                 row++;
                 return;
             }
-            value = this.innerHTML;
+            var value = table_rows[row]["{{ title }}"];
+            {% if tuple.0.custom_content %}
+            value = custom_func(value, table_rows[row]);
+            {% endif %}
             if (value !== "" && !detail_mode) {
                 this.style.backgroundColor = scale(value);
             }
@@ -533,7 +539,7 @@ function render(additional_headers, displayed_columns, table_rows, columns) {
 {% endfor %}
 
 {% for title, tick_plot in heatmaps %}
-    colorizeColumn{{ loop.index0 }}(additional_headers.length, displayed_columns);
+    colorizeColumn{{ loop.index0 }}(additional_headers.length, displayed_columns, table_rows);
 {% endfor %}
 
 {% for title, ellipsis in ellipses %}

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -75,7 +75,12 @@ $(document).ready(function() {
         renderCustomPlotDetailView{{ loop.index0 }}(row[cp[{{ loop.index0 }}]], `#detail-plot-${index}-cp-{{ loop.index0 }}`);
         {% endfor %}
         {% for title, tuple in heatmaps %}
+        {% if tuple.0.custom_content %}
+        var custom_func{{ loop.index0 }} =  {{ tuple.0.custom_content }};
+        colorizeDetailCard{{ loop.index0 }}(custom_func{{ loop.index0 }}(row[heatmaps[{{ loop.index0 }}]], row), `#heatmap-${index}-{{ loop.index0 }}`);
+        {% else %}
         colorizeDetailCard{{ loop.index0 }}(row[heatmaps[{{ loop.index0 }}]], `#heatmap-${index}-{{ loop.index0 }}`);
+        {% endif %}
         {% endfor %}
         {% for title, tick_plot in tick_plots %}
         renderDetailTickPlots{{ loop.index0 }}(row[ticks[{{ loop.index0 }}]], `#detail-plot-${index}-ticks-{{ loop.index0 }}`);
@@ -357,12 +362,13 @@ function renderDetailTickPlots{{ loop.index0 }}(value, div) {
 {% endfor %}
 
 {% for title, tuple in heatmaps %}
-function colorizeColumn{{ loop.index0 }}(ah, columns, table_rows) {
+function colorizeColumn{{ loop.index0 }}(ah, columns) {
     let detail_mode = columns.indexOf("{{ title }}") == -1;
     let index = columns.indexOf("{{ title }}") + 1{% if detail_mode %} + 1{% endif %};
     var {{ tuple.0.scale }} = vega.scale('{{ tuple.0.scale }}');
     var scale = {{ tuple.0.scale }}().domain({{ tuple.1 }}).range({% if tuple.0.color_scheme %}vega.scheme('{{ tuple.0.color_scheme }}'){% else %}[{% for color in tuple.0.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
     let row = 0;
+    var table_rows = $("#table").bootstrapTable('getData', {useCurrentPage: "true"});
     {% if tuple.0.custom_content %}
     var custom_func = {{ tuple.0.custom_content }};
     {% endif %}
@@ -539,7 +545,7 @@ function render(additional_headers, displayed_columns, table_rows, columns) {
 {% endfor %}
 
 {% for title, tick_plot in heatmaps %}
-    colorizeColumn{{ loop.index0 }}(additional_headers.length, displayed_columns, table_rows);
+    colorizeColumn{{ loop.index0 }}(additional_headers.length, displayed_columns);
 {% endfor %}
 
 {% for title, ellipsis in ellipses %}


### PR DESCRIPTION
This PR allows the user to customize the value that will be used for a heatmap with the new keyword `custom-content` and therefore closes #170.