### PR TITLE
feat!: rename header-rows setting into headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ datasets:
     separator: ;
   gene-mycn:
     path: "genes/table-mycn.csv"
-    header-rows: 2
+    headers: 2
     links:
       some expression:
         column: quality
@@ -159,10 +159,10 @@ views:
 
 `render-table` contains definitions for a table view
 
-| keyword                                    | explanation                                   |
-| -------------------------------------------|-----------------------------------------------|
-| [columns](#columns)                        | Configuration of columns                      |
-| [additional-headers](#additional-headers)  | Configuration of the additional headers       |
+| keyword                                   | explanation                                   |
+| ------------------------------------------|-----------------------------------------------|
+| [columns](#columns)                       | Configuration of columns                      |
+| [headers](#headers)  | Configuration of the additional headers       |
 
 ### columns
 
@@ -179,13 +179,13 @@ views:
 | display-mode                | Allows to hide columns from views by setting this to `hidden` or have a column only in [detail view](https://examples.bootstrap-table.com/#options/detail-view.html#view-source) by setting this to `detail`. | normal  | detail, normal, hidden |
 
 
-### additional-headers
+### headers
 
-`additional-headers` contains definitions for additional header rows. Each row can be accessed with its index strating from `0`:
+`headers` contains definitions for additional header rows. Each row can be accessed with its index starting at `1` (`0` is the first header row that can't be customized).
 
-| keyword                                    | explanation                                                                                                                                      |
-| -------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| [plot](#plot)               | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell (currently only the [heatmap](#heatmap) type is supported in header rows)   |
+| keyword                       | explanation                                                                                                                                      |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [plot](#plot)                 | Renders a vega-lite plot defined with [plot](#plot) to the corresponding table cell (currently only the [heatmap](#heatmap) type is supported in header rows)   |
 
 ### render-plot
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -5,7 +5,7 @@ use crate::render::portable::plot::get_min_max;
 use crate::render::portable::plot::render_plots;
 use crate::render::Renderer;
 use crate::spec::{
-    AdditionalHeaderSpecs, CustomPlot, DatasetSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec,
+    CustomPlot, DatasetSpecs, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec,
     RenderColumnSpec, TickPlot,
 };
 use crate::utils::column_index::ColumnIndex;
@@ -188,7 +188,7 @@ impl Renderer for ItemRenderer {
                         dataset.separator,
                         table_specs,
                         additional_headers,
-                        &table.render_table.as_ref().unwrap().additional_headers,
+                        &table.render_table.as_ref().unwrap().headers,
                         is_single_page,
                         table.single_page_page_size,
                     )?;
@@ -309,7 +309,7 @@ fn render_table_javascript<P: AsRef<Path>>(
     separator: char,
     render_columns: &HashMap<String, RenderColumnSpec>,
     additional_headers: Option<Vec<StringRecord>>,
-    header_plots: &Option<HashMap<u32, AdditionalHeaderSpecs>>,
+    header_plots: &Option<HashMap<u32, HeaderSpecs>>,
     is_single_page: bool,
     page_size: usize,
 ) -> Result<()> {

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -407,7 +407,7 @@ function colorizeHeaderRow{{ loop.index0 }}() {
     var {{ heatmap.scale }} = vega.scale('{{ heatmap.scale }}');
     var scale = {{ heatmap.scale }}(){% if heatmap.domain %}.domain({{ heatmap.domain | json }}){% endif %}.range({% if heatmap.color_scheme %}vega.scheme('{{ heatmap.color_scheme }}'){% else %}[{% for color in heatmap.range %}"{{ color }}"{% if not loop.last %},{% endif %}{% endfor %}]{% endif %});
     var row = {{ row }};
-    $(`table > thead > tr:nth-child(${row + 2}) > td`).each(
+    $(`table > thead > tr:nth-child(${row + 1}) > td`).each(
         function() {
             var value = this.innerHTML;
     console.log(value);


### PR DESCRIPTION
This PR does some refactoring regarding the newly added `additional-headers` keyword.