### PR TITLE
feat: Align text markers of tick plots

### DIFF
--- a/templates/tick_plot.vl.tera
+++ b/templates/tick_plot.vl.tera
@@ -21,7 +21,7 @@
         {"mark": "tick"},
         {
         "mark": {"type": "text", "yOffset": -8, "xOffset": 12},
-        "encoding": {"text": {"field": "{{ field }}"}}
+        "encoding": {"x": {"value": 0}, "text": {"field": "{{ field }}"}}
         }
     ],
     "config": {


### PR DESCRIPTION
This PR aligns the text markers of the tick plots so they are always readable and do not overflow to the right.