### PR TITLE
refactor: Use derive for default implementation of enum

### DIFF
--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -4,19 +4,13 @@ use std::iter::FromIterator;
 use std::path::Path;
 use std::str::FromStr;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub(crate) enum ColumnType {
+    #[default]
     None,
     String,
     Integer,
     Float,
-}
-
-// TODO: Use Derive once its stabilized: https://github.com/rust-lang/rust/issues/86985
-impl Default for ColumnType {
-    fn default() -> Self {
-        ColumnType::None
-    }
 }
 
 impl ColumnType {


### PR DESCRIPTION
Just some quick refactoring removing an earlier todo regarding the default implementation for an enum.