### PR TITLE
feat: Add minify_js to decrease file sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lz-str",
+ "minify-js",
  "ndhistogram",
  "regex",
  "serde",
@@ -461,6 +462,17 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minify-js"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e057de7e5b920675f6c9de1a7d1b6862685f4e57953ee083ce01233e4b5cac"
+dependencies = [
+ "aho-corasick",
+ "lazy_static",
+ "memchr",
+]
 
 [[package]]
 name = "ndhistogram"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static = "1.4.0"
 regex = "1.6.0"
 log = "0.4.17"
 simplelog = "0.12.0"
+minify-js = "0.2.4"
 
 [dev-dependencies]
 dir-assert = "0.2.0"

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod utils;
 
 use crate::render::portable::plot::get_min_max;
 use crate::render::portable::plot::render_plots;
+use crate::render::portable::utils::minify_js;
 use crate::render::Renderer;
 use crate::spec::{
     CustomPlot, DatasetSpecs, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec,
@@ -533,8 +534,9 @@ fn render_table_javascript<P: AsRef<Path>>(
 
     let js = templates.render("table.js.tera", &context)?;
 
-    let mut file = fs::File::create(file_path)?;
-    file.write_all(js.as_bytes())?;
+    let mut file = File::create(file_path)?;
+    let minified = minify_js(&js)?;
+    file.write_all(&minified)?;
 
     Ok(())
 }

--- a/src/render/portable/plot.rs
+++ b/src/render/portable/plot.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 use tera::{Context, Tera};
+use crate::render::portable::utils::minify_js;
 
 /// Renders plots to javascript file
 pub(crate) fn render_plots<P: AsRef<Path>>(
@@ -58,7 +59,8 @@ pub(crate) fn render_plots<P: AsRef<Path>>(
         let js = templates.render("plot.js.tera", &context)?;
         let file_path = path.join(Path::new(&format!("plot_{}", index)).with_extension("js"));
         let mut file = fs::File::create(file_path)?;
-        file.write_all(js.as_bytes())?;
+        let minified = minify_js(&js)?;
+        file.write_all(&minified)?;
     }
     Ok(())
 }

--- a/src/render/portable/plot.rs
+++ b/src/render/portable/plot.rs
@@ -1,3 +1,4 @@
+use crate::render::portable::utils::minify_js;
 use crate::utils::column_type::{classify_table, ColumnType};
 use anyhow::{Context as AnyhowContext, Result};
 use csv::Reader;
@@ -13,7 +14,6 @@ use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 use tera::{Context, Tera};
-use crate::render::portable::utils::minify_js;
 
 /// Renders plots to javascript file
 pub(crate) fn render_plots<P: AsRef<Path>>(

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -1,5 +1,6 @@
 use crate::spec::ItemsSpec;
 use anyhow::Result;
+use minify_js::{minify, TopLevelMode};
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -73,9 +74,21 @@ pub(crate) fn render_static_files<P: AsRef<Path>>(path: P) -> Result<()> {
 
     for (name, file) in files {
         let mut out = File::create(path.join(Path::new(name)))?;
-        out.write_all(file.as_bytes())?;
+        let minified = minify_js(file)?;
+        out.write_all(&minified)?;
     }
     Ok(())
+}
+
+pub(crate) fn minify_js(file: &str) -> Result<Vec<u8>> {
+    let mut minified: Vec<u8> = Vec::new();
+    minify(
+        TopLevelMode::Global,
+        file.as_bytes().to_vec(),
+        &mut minified,
+    )
+    .expect("Failed minifying js");
+    Ok(minified)
 }
 
 pub(crate) fn render_index_file<P: AsRef<Path>>(path: P, specs: &ItemsSpec) -> Result<()> {

--- a/src/render/portable/utils.rs
+++ b/src/render/portable/utils.rs
@@ -74,8 +74,7 @@ pub(crate) fn render_static_files<P: AsRef<Path>>(path: P) -> Result<()> {
 
     for (name, file) in files {
         let mut out = File::create(path.join(Path::new(name)))?;
-        let minified = minify_js(file)?;
-        out.write_all(&minified)?;
+        out.write_all(file.as_bytes())?;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR uses `minify_js` to minify rendered js files before writing. This should reduce file sizes slightly.
I probably haven't caught all places js files are written, feel free to add any that I missed ;)

(It may also be interesting to minify the html files, haven't looked into that, yet)