### PR TITLE
fix: Fix entering of unreachable code when data contains empty columns

### DIFF
--- a/src/render/portable/plot.rs
+++ b/src/render/portable/plot.rs
@@ -37,8 +37,8 @@ pub(crate) fn render_plots<P: AsRef<Path>>(
         context.insert("title", &column);
         context.insert("index", &index);
         match column_types.get(column) {
-            None | Some(ColumnType::None) => unreachable!(),
-            Some(ColumnType::String) => {
+            None => unreachable!(),
+            Some(ColumnType::String) | Some(ColumnType::None) => {
                 let plot = generate_nominal_plot(csv_path, separator, index, header_rows)?;
                 templates.add_raw_template(
                     "plot.js.tera",


### PR DESCRIPTION
This PR fixes the possible entering of unreachable code when data contains empty columns by treating empty columns like they were of the type `String`. This bug was probably introduced when #206 changed the overall behavior of empty values in datasets.