### PR TITLE
fix: Fix brush filter domain for numeric heatmap plots

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -182,7 +182,7 @@ $(document).ready(function() {
                let max = Math.max(...values);
                if (brush_domains[title] != undefined) {
                    min = brush_domains[title][0];
-                   max = brush_domains[title][1];
+                   max = brush_domains[title][brush_domains[title].length - 1];
                } else if (aux_domains[title] != undefined) {
                    aux_values = [min, max];
                    for (col of aux_domains[title]) {

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -181,8 +181,9 @@ $(document).ready(function() {
                let min = Math.min(...values);
                let max = Math.max(...values);
                if (brush_domains[title] != undefined) {
-                   min = brush_domains[title][0];
-                   max = brush_domains[title][brush_domains[title].length - 1];
+                    console.log(brush_domains[title])
+                   min = Math.min(...brush_domains[title]);
+                   max = Math.max(...brush_domains[title]);
                } else if (aux_domains[title] != undefined) {
                    aux_values = [min, max];
                    for (col of aux_domains[title]) {

--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -181,7 +181,6 @@ $(document).ready(function() {
                let min = Math.min(...values);
                let max = Math.max(...values);
                if (brush_domains[title] != undefined) {
-                    console.log(brush_domains[title])
                    min = Math.min(...brush_domains[title]);
                    max = Math.max(...brush_domains[title]);
                } else if (aux_domains[title] != undefined) {


### PR DESCRIPTION
This PR fixes the brush filter domains for columns that have a domain with more than two values i.e numeric heatmap definitions where `range` is used.