### PR TITLE
fix: Align text marks of heatmap table

### DIFF
--- a/templates/table_heatmap.js.tera
+++ b/templates/table_heatmap.js.tera
@@ -6,13 +6,17 @@ const heatmap_plot = {
     "hconcat": [
         {% for column in columns %}
         {
-            "mark": "{{ marks[column] }}",
+            "mark": {
+                "type": "{{ marks[column] }}"{% if marks[column] == "text" %},
+                "align":"left"{% endif %}
+            },
             "encoding": {
                 "x": {
                 "field": "dummy",
                     "axis": {
                         "labelExpr": "'{{ column }}'",
                         "labelAngle": -45,
+                        {% if marks[column] == "text" %}"labelOffset": 7,{% endif %}
                         "title": null,
                         "ticks": false,
                         "orient": "top",

--- a/templates/table_heatmap.js.tera
+++ b/templates/table_heatmap.js.tera
@@ -38,11 +38,11 @@ const heatmap_plot = {
                         {% if schemes[column] %}"scheme": "{{ schemes[column] }}",{% elif not ranges[column] and types[column] == "quantitative" %}"scheme": "blues",{% endif %}
                         {% if ranges[column] %}"range": {{ ranges[column] | json_encode }},{% endif %}
                     },{% endif %}
-                    "legend": {
+                    {% if marks[column] != "text" %}"legend": {
                         "orient": "bottom",
                         "direction": "vertical",
                         "gradientLength": 50
-                    }
+                    }{% endif %}
                 }
             }
         }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
This PR fixes some minor styling issues with the recently added heat map export function.