### PR TITLE
feat: Merge legends when domains are equal

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -448,9 +448,9 @@ fn render_table_heatmap<P: AsRef<Path>>(
                 heatmap_domains.get(t1),
                 heatmap_domains.get(t2),
             ) {
-                (Some(d1), Some(d2), _, _) => (t2, d1 == d2),
-                (_, _, Some(d1), Some(d2)) => (t2, d1 == d2),
-                _ => (t2, false),
+                (Some(d1), Some(d2), _, _) => (t1, d1 == d2),
+                (_, _, Some(d1), Some(d2)) => (t1, d1 == d2),
+                _ => (t1, false),
             }
         })
         .collect();

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -438,6 +438,24 @@ fn render_table_heatmap<P: AsRef<Path>>(
         .filter(|(_, s)| !s.is_empty())
         .collect();
 
+    let remove_legend: HashMap<_, _> = titles
+        .iter()
+        .tuple_windows()
+        .map(|(t1, t2)| {
+            match (
+                tick_domains.get(t1),
+                tick_domains.get(t2),
+                heatmap_domains.get(t1),
+                heatmap_domains.get(t2),
+            ) {
+                (Some(d1), Some(d2), _, _) => (t2, d1 == d2),
+                (_, _, Some(d1), Some(d2)) => (t2, d1 == d2),
+                _ => (t2, false),
+            }
+        })
+        .collect();
+
+    context.insert("remove_legend", &remove_legend);
     context.insert("tick_domains", &tick_domains);
     context.insert("heatmap_domains", &heatmap_domains);
     context.insert("ranges", &ranges);
@@ -915,6 +933,7 @@ fn get_column_domain(
                         .map(|(_, value)| value.to_string())
                         .collect_vec())
                     .unique()
+                    .sorted()
                     .collect_vec())
                 .to_string())
             } else {
@@ -923,6 +942,7 @@ fn get_column_domain(
                     .map(|r| r.unwrap())
                     .map(|r| r.get(column_index).unwrap().to_owned())
                     .unique()
+                    .sorted()
                     .collect_vec())
                 .to_string())
             }

--- a/templates/table_heatmap.js.tera
+++ b/templates/table_heatmap.js.tera
@@ -50,7 +50,7 @@ const heatmap_plot = {
     ],
     "config": {
         "style": {"cell": {"stroke": "transparent"}, "guide-label": {"fontWeight": "bold"}},
-        "concat": {"spacing": 4},
+        "concat": {"spacing": 0},
         "text": {"limit": 135}
     }
 }

--- a/templates/table_heatmap.js.tera
+++ b/templates/table_heatmap.js.tera
@@ -15,7 +15,7 @@ const heatmap_plot = {
                 "field": "dummy",
                     "axis": {
                         "labelExpr": "'{{ column }}'",
-                        "labelAngle": -45,
+                        "labelAngle": -90,
                         {% if marks[column] == "text" %}"labelOffset": 7,{% endif %}
                         "title": null,
                         "ticks": false,
@@ -38,11 +38,11 @@ const heatmap_plot = {
                         {% if schemes[column] %}"scheme": "{{ schemes[column] }}",{% elif not ranges[column] and types[column] == "quantitative" %}"scheme": "blues",{% endif %}
                         {% if ranges[column] %}"range": {{ ranges[column] | json_encode }},{% endif %}
                     },{% endif %}
-                    {% if marks[column] != "text" %}"legend": {
+                    {% if marks[column] != "text" %}"legend": {% if remove_legend[column] %}null{% else %}{
                         "orient": "bottom",
                         "direction": "vertical",
                         "gradientLength": 50
-                    }{% endif %}
+                    }{% endif %}{% endif %}
                 }
             }
         }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
This PR merges two or more legends if the columns share the same domain (including aux-domains) and the columns are neighboured. This makes the plot-view much more compact for some use-cases.