### PR TITLE
fix: Fix precision behaviour for zero and negative values

### DIFF
--- a/templates/table.js.tera
+++ b/templates/table.js.tera
@@ -317,7 +317,7 @@ function renderMarkdownDescription() {
 
 function precision_formatter(precision, value) {
     value = parseFloat(value)
-    if (1 / (10 ** precision) < value) {
+    if (1 / (10 ** precision) < Math.abs(value) || value == 0) {
         return value.toFixed(precision).toString()
     } else {
         return value.toExponential(precision)


### PR DESCRIPTION
This PR fixes the behavior of `precision` for `0.0` and negative values that were missing a `Math.abs()`.