### PR TITLE
fix: Add context to error when parsing numeric domain

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -562,7 +562,7 @@ fn render_table_javascript<P: AsRef<Path>>(
                 .map(|(title, k)| {
                     (
                         title.to_string(),
-                        k.iter().map(|s| f32::from_str(s).unwrap()).collect_vec(),
+                        k.iter().map(|s| f32::from_str(s).context(format!("Could not parse given domain value {s} for column {title}.")).unwrap()).collect_vec(),
                     )
                 }),
         )


### PR DESCRIPTION
This PR adds a context when there is a problem with parsing a numeric domain in a heatmap.