### PR TITLE
fix: Fix wrong classification of empty columns

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -508,7 +508,7 @@ fn render_table_javascript<P: AsRef<Path>>(
 
     let numeric: HashMap<String, bool> = classify_table(csv_path, separator)?
         .iter()
-        .map(|(k, v)| (k.to_owned(), *v != ColumnType::String))
+        .map(|(k, v)| (k.to_owned(), v.is_numeric()))
         .collect();
 
     let is_float: HashMap<String, bool> = classify_table(csv_path, separator)?

--- a/src/utils/column_type.rs
+++ b/src/utils/column_type.rs
@@ -33,6 +33,10 @@ impl ColumnType {
         }
         Ok(())
     }
+
+    pub(crate) fn is_numeric(&self) -> bool {
+        self == &ColumnType::Integer || self == &ColumnType::Float
+    }
 }
 
 /// Classifies table columns as String, Integer or Float
@@ -107,5 +111,17 @@ mod tests {
         for column_type in classification.values() {
             assert_eq!(&ColumnType::None, column_type)
         }
+    }
+
+    #[test]
+    fn test_is_numeric() {
+        let integer = ColumnType::Integer;
+        let float = ColumnType::Float;
+        let string = ColumnType::String;
+        let none = ColumnType::None;
+        assert!(integer.is_numeric());
+        assert!(float.is_numeric());
+        assert!(!string.is_numeric());
+        assert!(!none.is_numeric())
     }
 }


### PR DESCRIPTION
This PR fixes a problem where empty columns were falsely classified as numeric.