### PR TITLE
fix: Fix overlapping fonts by removing line breaks

### DIFF
--- a/static/datavzrd.css
+++ b/static/datavzrd.css
@@ -107,6 +107,7 @@ td {
     font-size: 12px !important;
     /* Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=688556 see https://github.com/koesterlab/datavzrd/issues/144 */
     background-clip: padding-box;
+    white-space: nowrap;
 }
 
 .table td.plotcell {


### PR DESCRIPTION
This PR adds `white-space: nowrap;` to table cells so they don't overlap each other in a weird way.