### PR TITLE
refactor: Change scale types etc. to enum

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -6,8 +6,8 @@ use crate::render::portable::plot::render_plots;
 use crate::render::portable::utils::minify_js;
 use crate::render::Renderer;
 use crate::spec::{
-    BarPlot, CustomPlot, DatasetSpecs, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec,
-    RenderColumnSpec, ScaleType, TickPlot,
+    BarPlot, CustomPlot, DatasetSpecs, DisplayMode, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec,
+    LinkSpec, RenderColumnSpec, ScaleType, TickPlot,
 };
 use crate::utils::column_index::ColumnIndex;
 use crate::utils::column_type::{classify_table, ColumnType};
@@ -334,7 +334,7 @@ fn render_table_heatmap<P: AsRef<Path>>(
 
     let hidden_columns: HashSet<_> = render_columns
         .iter()
-        .filter(|(_, v)| v.display_mode == "hidden")
+        .filter(|(_, v)| v.display_mode == DisplayMode::Hidden)
         .map(|(k, _)| k)
         .collect();
 
@@ -739,16 +739,16 @@ fn render_table_javascript<P: AsRef<Path>>(
         .map(|(t, spec)| (t.to_string(), spec.ellipsis.unwrap()))
         .collect();
 
-    let mut display_modes: HashMap<String, String> = titles
+    let mut display_modes: HashMap<String, DisplayMode> = titles
         .iter()
-        .map(|t| (t.to_string(), "normal".to_string()))
+        .map(|t| (t.to_string(), DisplayMode::Normal))
         .collect();
     for (title, rc) in render_columns {
-        display_modes.insert(title.to_string(), rc.display_mode.to_string());
+        display_modes.insert(title.to_string(), rc.display_mode);
     }
     let detail_mode = display_modes
         .iter()
-        .filter(|(_, mode)| *mode == "detail")
+        .filter(|(_, mode)| *mode == &DisplayMode::Detail)
         .count()
         > 0;
 

--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -412,14 +412,14 @@ fn render_table_heatmap<P: AsRef<Path>>(
         .map(|(t, rc)| (t, rc.plot.as_ref().unwrap()))
         .map(|(t, p)| {
             if let Some(heatmap) = &p.heatmap {
-                (t, &heatmap.scale_type)
+                (t, heatmap.scale_type)
             } else if let Some(ticks) = &p.tick_plot {
-                (t, &ticks.scale_type)
+                (t, ticks.scale_type)
             } else {
-                (t, &ScaleType::None)
+                (t, ScaleType::None)
             }
         })
-        .filter(|(_, s)| s != &&ScaleType::None)
+        .filter(|(_, s)| s != &ScaleType::None)
         .collect();
 
     let ranges: HashMap<_, _> = render_columns

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -14,11 +14,11 @@ use serde::Serialize;
 use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::fs;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::{fmt, fs};
 use thiserror::Error;
 
 #[derive(Derefable, Deserialize, Debug, Clone, PartialEq)]
@@ -579,20 +579,14 @@ pub(crate) enum ScaleType {
 
 impl ScaleType {
     pub(crate) fn is_quantitative(&self) -> bool {
-        match self {
+        matches!(
+            self,
             ScaleType::Linear
-            | ScaleType::Pow
-            | ScaleType::Sqrt
-            | ScaleType::SymLog
-            | ScaleType::Log => true,
-            _ => false,
-        }
-    }
-}
-
-impl fmt::Display for ScaleType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+                | ScaleType::Pow
+                | ScaleType::Sqrt
+                | ScaleType::SymLog
+                | ScaleType::Log
+        )
     }
 }
 
@@ -687,7 +681,7 @@ mod tests {
         default_display_mode, default_links, default_precision, default_render_table,
         default_single_page_threshold, AuxDomainColumns, DatasetSpecs, HeaderSpecs, Heatmap,
         ItemSpecs, ItemsSpec, LinkSpec, PlotSpec, RenderColumnSpec, RenderHtmlSpec, RenderPlotSpec,
-        RenderTableSpecs, TickPlot,
+        RenderTableSpecs, ScaleType, TickPlot,
     };
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -898,7 +892,7 @@ mod tests {
                         plot: Some(PlotSpec {
                             tick_plot: None,
                             heatmap: Some(Heatmap {
-                                scale_type: "ordinal".to_string(),
+                                scale_type: ScaleType::Ordinal,
                                 clamp: true,
                                 color_scheme: "category20".to_string(),
                                 color_range: vec![],
@@ -1106,8 +1100,8 @@ mod tests {
                                     heatmap:
                                         scale: inverse-quadruplic
             "#;
-        let config: ItemsSpec = serde_yaml::from_str(raw_config).unwrap();
-        assert!(config.validate().is_err());
+        let config = serde_yaml::from_str::<ItemSpecs>(raw_config).is_err();
+        assert!(config);
     }
 
     #[test]
@@ -1223,7 +1217,7 @@ mod tests {
             )
             .unwrap();
         let expected_ticks = TickPlot {
-            scale_type: "linear".to_string(),
+            scale_type: ScaleType::Linear,
             domain: None,
             aux_domain_columns: AuxDomainColumns(Some(vec![
                 "birth_mo".to_string(),

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -561,7 +561,7 @@ pub(crate) struct BarPlot {
     pub(crate) aux_domain_columns: AuxDomainColumns,
 }
 
-#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ScaleType {
     Linear,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -678,7 +678,12 @@ pub enum ConfigError {
 
 #[cfg(test)]
 mod tests {
-    use crate::spec::{default_links, default_precision, default_render_table, default_single_page_threshold, AuxDomainColumns, DatasetSpecs, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec, PlotSpec, RenderColumnSpec, RenderHtmlSpec, RenderPlotSpec, RenderTableSpecs, ScaleType, TickPlot, DisplayMode};
+    use crate::spec::{
+        default_links, default_precision, default_render_table, default_single_page_threshold,
+        AuxDomainColumns, DatasetSpecs, DisplayMode, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec,
+        LinkSpec, PlotSpec, RenderColumnSpec, RenderHtmlSpec, RenderPlotSpec, RenderTableSpecs,
+        ScaleType, TickPlot,
+    };
     use std::collections::HashMap;
     use std::path::PathBuf;
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -370,10 +370,6 @@ impl ItemSpecs {
     }
 }
 
-fn default_display_mode() -> String {
-    String::from("normal")
-}
-
 fn default_precision() -> u32 {
     2_u32
 }
@@ -387,8 +383,8 @@ pub(crate) struct RenderColumnSpec {
     pub(crate) precision: u32,
     #[serde(default)]
     pub(crate) custom: Option<String>,
-    #[serde(default = "default_display_mode")]
-    pub(crate) display_mode: String,
+    #[serde(default)]
+    pub(crate) display_mode: DisplayMode,
     #[serde(default)]
     pub(crate) link_to_url: Option<String>,
     #[serde(default)]
@@ -399,6 +395,15 @@ pub(crate) struct RenderColumnSpec {
     pub(crate) ellipsis: Option<u32>,
     #[serde(default)]
     pub(crate) plot_view_legend: bool,
+}
+
+#[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum DisplayMode {
+    #[default]
+    Normal,
+    Detail,
+    Hidden,
 }
 
 impl RenderColumnSpec {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -678,12 +678,7 @@ pub enum ConfigError {
 
 #[cfg(test)]
 mod tests {
-    use crate::spec::{
-        default_display_mode, default_links, default_precision, default_render_table,
-        default_single_page_threshold, AuxDomainColumns, DatasetSpecs, HeaderSpecs, Heatmap,
-        ItemSpecs, ItemsSpec, LinkSpec, PlotSpec, RenderColumnSpec, RenderHtmlSpec, RenderPlotSpec,
-        RenderTableSpecs, ScaleType, TickPlot,
-    };
+    use crate::spec::{default_links, default_precision, default_render_table, default_single_page_threshold, AuxDomainColumns, DatasetSpecs, HeaderSpecs, Heatmap, ItemSpecs, ItemsSpec, LinkSpec, PlotSpec, RenderColumnSpec, RenderHtmlSpec, RenderPlotSpec, RenderTableSpecs, ScaleType, TickPlot, DisplayMode};
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -693,7 +688,7 @@ mod tests {
             precision: default_precision(),
             optional: false,
             custom: None,
-            display_mode: "normal".to_string(),
+            display_mode: DisplayMode::Normal,
             link_to_url: Some("https://www.rust-lang.org".to_string()),
             plot: None,
             custom_plot: None,
@@ -1155,7 +1150,7 @@ mod tests {
             precision: default_precision(),
             optional: false,
             custom: None,
-            display_mode: "detail".to_string(),
+            display_mode: DisplayMode::Detail,
             link_to_url: None,
             plot: None,
             custom_plot: None,
@@ -1166,7 +1161,7 @@ mod tests {
             precision: default_precision(),
             optional: false,
             custom: None,
-            display_mode: "hidden".to_string(),
+            display_mode: DisplayMode::Hidden,
             link_to_url: None,
             plot: None,
             custom_plot: None,
@@ -1235,7 +1230,7 @@ mod tests {
             optional: false,
             precision: default_precision(),
             custom: None,
-            display_mode: default_display_mode(),
+            display_mode: DisplayMode::default(),
             link_to_url: None,
             plot: Some(expected_plot),
             custom_plot: None,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -484,8 +484,8 @@ pub(crate) struct CustomPlot {
     schema: Option<String>,
     #[serde(default, rename = "spec-path")]
     schema_path: Option<String>,
-    #[serde(default = "default_vega_controls")]
-    vega_controls: String,
+    #[serde(default)]
+    vega_controls: bool,
 }
 
 impl CustomPlot {
@@ -499,10 +499,6 @@ impl CustomPlot {
         }
         Ok(())
     }
-}
-
-fn default_vega_controls() -> String {
-    "false".to_string()
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
This PR changes scale types and multiple other types to an enum and therefore closes #254.