### PR TITLE
fix: Fix error when rendering empty multi header files

### DIFF
--- a/src/render/portable/mod.rs
+++ b/src/render/portable/mod.rs
@@ -532,7 +532,7 @@ fn get_column_width(
         .map(|row| row.get(column_index).unwrap().to_string())
         .map(|s| s.len())
         .max()
-        .unwrap();
+        .unwrap_or(0);
 
     Ok(width as i32)
 }


### PR DESCRIPTION
This PR fixes #253 by defaulting a columns width to 0 when there is no data to show.